### PR TITLE
feat: Add tiered Docker deployments and category documentation

### DIFF
--- a/categories/children/README.md
+++ b/categories/children/README.md
@@ -1,0 +1,478 @@
+# Children's Check-In / Check-Out
+
+> Secure, efficient systems for children's ministry safety and parent peace of mind.
+
+## Why It Matters
+
+Child safety is non-negotiable in churches. A proper check-in system:
+
+- Ensures only authorized adults pick up children
+- Provides allergy and medical alerts to workers
+- Maintains accurate attendance records
+- Enables emergency contact access
+- Gives parents confidence in your safety procedures
+
+## Key Requirements
+
+1. **Security First:** Unique guardian-pickup codes, photo verification
+2. **Speed:** Check-in must be < 30 seconds per family
+3. **Reliability:** Works without internet (or has offline mode)
+4. **Accessibility:** Easy for first-time guests
+5. **Integration:** Works with your ChMS
+
+---
+
+## ChurchApps Check-In
+
+**Status:** ✅ Very Active (last commit: 2025)
+
+**Skill Level:** Beginner
+
+**True Cost:**
+- Software: Free (open source)
+- Hosting: Cloud (free tier) or self-hosted
+- Hardware: Tablets/phones for check-in stations ($50-200 each)
+- Setup Time: 30 minutes (cloud) or 2-4 hours (self-hosted)
+- Ongoing Maintenance: Minimal
+
+**What It Does:**
+Purpose-built check-in system integrated with ChurchApps ChMS. Supports QR codes, phone number lookup, and name search. Prints labels with security codes, allergy alerts, and pickup permissions.
+
+**Why Churches Use It:**
+- Purpose-built for church child check-in
+- Multiple check-in methods (QR, phone, name search)
+- Prints security labels with unique codes
+- Allergy and special needs alerts on labels
+- Real-time room capacity monitoring
+- Parent mobile app for pre-check-in
+- Works offline with sync
+
+**Check-In Methods:**
+1. **QR Code:** Returning families scan QR code on their phone
+2. **Phone Number:** Quick lookup for regular families
+3. **Name Search:** For guests or when QR won't scan
+4. **Pre-check:** Parents check in via mobile app before arriving
+
+**Label Information:**
+- Child's name and age/grade
+- Security code (matches parent pickup tag)
+- Allergy alerts (prominent visual indicator)
+- Special needs notes
+- Parent/guardian contact
+
+**Installation:**
+- **Cloud:** Sign up at https://b1.church/ → Enable Check-in module
+- **Self-hosted:** Docker compose with ChurchApps stack
+
+**Hardware Requirements:**
+- Check-in stations: Tablets, phones, or computers with camera
+- Label printers: Brother QL-series recommended (USB or network)
+- Network: WiFi coverage in check-in area
+
+**Security Features:**
+- Unique security codes every week
+- Photo verification option
+- Authorized pickup list enforcement
+- Digital audit trail (who checked in/out, when)
+- Room capacity limits with alerts
+
+**Caveats:**
+- Requires ChurchApps account (either cloud or self-hosted)
+- Label printer setup can be tricky on some devices
+- Best experience requires modern tablets/phones
+- Self-hosted version needs API server + web app
+
+**Links:**
+- GitHub: https://github.com/ChurchApps/B1Admin
+- Website: https://b1.church/
+- Mobile App: "B1 Church" on iOS/Android
+
+---
+
+## ChurchCRM + Custom Check-In
+
+**Status:** ✅ Active (last commit: 2025)
+
+**Skill Level:** Intermediate to Advanced
+
+**True Cost:**
+- Software: Free
+- Hosting: $5-10/mo VPS
+- Development: 4-8 hours for basic QR check-in
+- Setup Time: 2-4 hours (ChurchCRM) + custom dev
+- Ongoing Maintenance: Low
+
+**What It Does:**
+ChurchCRM includes basic group/event check-in. For dedicated children's check-in, you'll need to build or extend the existing Sunday School check-in features.
+
+**Built-in Check-In:**
+ChurchCRM has `Checkin.php` for Sunday School classes:
+- Child check-in by name
+- Parent/guardian assignment
+- Classroom assignment
+- Basic attendance tracking
+
+**Extending for QR Codes:**
+```php
+// Basic approach to add QR check-in to ChurchCRM:
+// 1. Generate QR codes with family ID encoded
+// 2. Create check-in endpoint that:
+//    - Reads QR code → looks up family
+//    - Shows children in family
+//    - Records check-in to database
+//    - Prints label (if printer configured)
+// 3. Create check-out endpoint for secure pickup
+
+// Estimated development: 4-8 hours for basic version
+// PHP knowledge required
+```
+
+**DIY QR Check-In Architecture:**
+```
+[QR Code] → [Scanner/Camera] → [Web App] → [ChurchCRM Database]
+                                        ↓
+                                  [Label Printer]
+```
+
+**Why Churches Use It:**
+- Free and fully self-hosted
+- Data stays in your ChMS
+- Customizable to your exact needs
+- No per-check-in fees
+
+**Caveats:**
+- Requires PHP development skills to extend
+- No native mobile app
+- Label printing requires additional setup
+- No offline mode (requires internet)
+
+**Links:**
+- GitHub: https://github.com/ChurchCRM/CRM
+- Docs: https://github.com/ChurchCRM/CRM/wiki
+- Check-in code: https://github.com/ChurchCRM/CRM/blob/master/src/Checkin.php
+
+---
+
+## Jethro Pastoral Ministry Manager
+
+**Status:** ✅ Active (last commit: 2024)
+
+**Skill Level:** Intermediate
+
+**True Cost:**
+- Software: Free
+- Hosting: $5-10/mo VPS
+- Setup Time: 2-3 hours
+- Ongoing Maintenance: Low
+
+**What It Does:**
+Australian-developed church management system with attendance tracking, rosters, and basic check-in capabilities. Less feature-rich than dedicated check-in systems but functional for smaller churches.
+
+**Attendance Features:**
+- Sunday School attendance tracking
+- Roster management for children's ministries
+- Contact management for families
+- Basic check-in recording
+
+**Why Churches Use It:**
+- Simple, no-frills approach
+- Good for small churches already using Jethro
+- Australian support timezone
+- Less complex than ChurchCRM
+
+**Caveats:**
+- No QR code support (manual entry)
+- No label printing
+- Primarily designed for Australian churches
+- Smaller community than ChurchCRM
+
+**Links:**
+- GitHub: https://github.com/tbar0970/jethro-pmm
+- Website: https://jethro-pmm.sourceforge.net/
+
+---
+
+## DIY Self-Hosted Check-In System
+
+**Status:** Community Recipe
+
+**Skill Level:** Intermediate to Advanced
+
+**True Cost:**
+- Software: Free
+- Hosting: $5-10/mo VPS or local Raspberry Pi
+- Hardware: ~$100-300 per check-in station
+- Setup Time: 8-16 hours development + 2-4 hours deployment
+- Ongoing Maintenance: Low
+
+**Architecture Overview:**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    CHECK-IN STATION                          │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
+│  │  Tablet/PC   │  │ USB Camera   │  │ Label Printer│      │
+│  │  (Browser)   │  │ (for QR)     │  │ (Brother QL) │      │
+│  └──────────────┘  └──────────────┘  └──────────────┘      │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│                  CHECK-IN SERVER                             │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
+│  │   Web App    │  │   Database   │  │  QR Service  │      │
+│  │  (PHP/Node)  │  │  (SQLite/   │  │  (Generator  │      │
+│  │              │  │   MariaDB)   │  │   & Scanner) │      │
+│  └──────────────┘  └──────────────┘  └──────────────┘      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Technology Stack Options:**
+
+### Option A: PHP + MySQL (Beginner-Friendly)
+```php
+// Core components:
+// - qr_code table: id, family_id, hash, created_at
+// - checkin_log table: child_id, checked_in_at, checked_out_at, guardian_id
+// - children table: name, family_id, allergies, special_needs
+// - guardians table: name, phone, photo, authorized_pickup (boolean)
+
+// Libraries:
+// - chillerlan/php-qrcode (QR generation)
+// - endroid/qr-code (alternative)
+// - jquery (frontend)
+// - Bootstrap (UI)
+```
+
+### Option B: Node.js + SQLite (Lightweight)
+```javascript
+// Core components:
+// - Express.js web server
+// - Better-sqlite3 database
+// - qrcode library
+// - jsQR (QR scanning in browser)
+// - Pug/EJS templates
+
+// Benefits:
+// - Single-file database (easy backup)
+// - Fast setup
+// - Good for single-check-in-station deployments
+```
+
+### Option C: Python + Flask (Rapid Development)
+```python
+# Core components:
+# - Flask web framework
+# - SQLAlchemy ORM
+# - qrcode library
+# - pyzbar (QR decoding)
+# - Jinja2 templates
+
+# Benefits:
+# - Very readable code
+# - Easy to extend
+# - Good for custom integrations
+```
+
+**Hardware Shopping List (Per Station):**
+- Tablet or cheap laptop: $50-150 (Amazon Fire tablet, used iPad, Chromebook)
+- USB webcam (if device lacks camera): $15-30
+- Brother QL-800 label printer: $80-120
+- Labels (continuous roll DK-2205): $15/roll
+- Optional: Tablet stand/enclosure: $20-40
+
+**Security Best Practices:**
+1. **Unique Security Codes:** Generate random 4-6 digit codes each week
+2. **Code Expiration:** Codes expire after service ends
+3. **Photo Verification:** Optional photo display on guardian record
+4. **Authorized Pickup List:** Enforce strictly — no exceptions
+5. **Audit Logging:** Log every check-in/out with timestamp and user
+6. **Data Encryption:** Encrypt sensitive child data at rest
+7. **Network Security:** HTTPS only, local network preferred
+8. **Physical Security:** Secure check-in stations, controlled access to printers
+
+**Sample Database Schema:**
+```sql
+-- Families
+CREATE TABLE families (
+    id INTEGER PRIMARY KEY,
+    family_name TEXT NOT NULL,
+    phone TEXT,
+    email TEXT,
+    qr_code_hash TEXT UNIQUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Children
+CREATE TABLE children (
+    id INTEGER PRIMARY KEY,
+    family_id INTEGER,
+    first_name TEXT NOT NULL,
+    last_name TEXT NOT NULL,
+    birth_date DATE,
+    allergies TEXT,
+    special_needs TEXT,
+    photo_path TEXT,
+    FOREIGN KEY (family_id) REFERENCES families(id)
+);
+
+-- Guardians/Parents
+CREATE TABLE guardians (
+    id INTEGER PRIMARY KEY,
+    family_id INTEGER,
+    first_name TEXT NOT NULL,
+    last_name TEXT NOT NULL,
+    phone TEXT NOT NULL,
+    photo_path TEXT,
+    authorized_pickup BOOLEAN DEFAULT 1,
+    is_primary BOOLEAN DEFAULT 0,
+    FOREIGN KEY (family_id) REFERENCES families(id)
+);
+
+-- Check-in/Out Log
+CREATE TABLE checkin_log (
+    id INTEGER PRIMARY KEY,
+    child_id INTEGER,
+    guardian_checkin_id INTEGER,
+    guardian_checkout_id INTEGER,
+    room_id INTEGER,
+    security_code TEXT,
+    checked_in_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    checked_out_at TIMESTAMP NULL,
+    FOREIGN KEY (child_id) REFERENCES children(id),
+    FOREIGN KEY (guardian_checkin_id) REFERENCES guardians(id),
+    FOREIGN KEY (guardian_checkout_id) REFERENCES guardians(id)
+);
+
+-- Service/Sessions
+CREATE TABLE services (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    service_date DATE,
+    start_time TIME,
+    end_time TIME
+);
+```
+
+**Label Template (2.4" x 3.9" Brother label):**
+```
+┌─────────────────────────────┐
+│  [CHURCH LOGO]              │
+│                             │
+│  Emma Johnson               │
+│  Age 4 / Preschool          │
+│                             │
+│  ⚠️ NUT ALLERGY             │
+│                             │
+│  Security Code: 4582        │
+│  Room: 201                  │
+│                             │
+│  [BARCODE: 4582]            │
+└─────────────────────────────┘
+```
+
+**Recommended Open Source Libraries:**
+- **QR Generation:**
+  - PHP: `chillerlan/php-qrcode`, `endroid/qr-code`
+  - Node.js: `qrcode` (npm)
+  - Python: `qrcode` (PyPI)
+  
+- **QR Scanning (Browser-based):**
+  - `html5-qrcode` (JavaScript library)
+  - `jsQR` (pure JavaScript QR decoder)
+  - `zxing-js` (port of ZXing)
+
+- **Label Printing:**
+  - Brother QL: `brother_ql` (Python)
+  - Generic: CUPS printing with PDF generation
+
+**Caveats:**
+- Requires technical expertise to build and maintain
+- No commercial support
+- You are responsible for security and compliance
+- Plan for 8-16 hours of development time
+
+---
+
+## Comparison Matrix
+
+| Feature | ChurchApps | ChurchCRM+Custom | Jethro | DIY System |
+|---------|------------|------------------|--------|------------|
+| **QR Code Check-In** | ✅ | ⚠️ (custom dev) | ❌ | ✅ (build it) |
+| **Label Printing** | ✅ | ⚠️ (custom dev) | ❌ | ✅ (build it) |
+| **Offline Mode** | ✅ | ❌ | ❌ | ✅ (build it) |
+| **Mobile App** | ✅ Native | ❌ | ❌ | ❌ (PWA possible) |
+| **Pre-check-in** | ✅ | ❌ | ❌ | ✅ (build it) |
+| **Setup Time** | 30 min | 4-8 hrs | 2-3 hrs | 8-16 hrs |
+| **Skill Level** | Beginner | Intermediate | Intermediate | Advanced |
+| **Cost** | Free | Free | Free | Free (+ dev time) |
+
+---
+
+## Security Checklist
+
+☐ **Unique security codes** every service/session  
+☐ **Authorized pickup list** strictly enforced  
+☐ **Photo verification** for unknown guardians  
+☐ **Two-person rule** for children under 2  
+☐ **Room capacity limits** enforced by system  
+☐ **Emergency contact** info readily accessible  
+☐ **Audit log** of all check-ins/outs  
+☐ **Background checks** documented for all workers  
+☐ **Secure network** (HTTPS, local preferred)  
+☐ **Backup plan** if system fails (paper backup)  
+
+---
+
+## Recommendations by Church Size
+
+### Church Plant (< 50 people)
+**Use:** Paper sign-in sheets or simple spreadsheet
+- Not worth the complexity yet
+- Use printed name tags with highlighters for allergies
+
+### Small Church (50-200)
+**Use:** ChurchApps Cloud (free tier)
+- Professional check-in with minimal setup
+- Native mobile apps included
+- Scales as you grow
+
+### Mid-Size Church (200-1000)
+**Use:** ChurchApps (self-hosted) or DIY system
+- Self-hosted gives you full control
+- DIY option if you have development resources
+- Multiple check-in stations needed
+
+### Large Church (1000+)
+**Use:** Evaluate ChurchApps vs commercial solutions
+- May need multiple concurrent check-in stations
+- Consider integration with access control systems
+- Professional support may be worth the cost
+
+---
+
+## Integration Notes
+
+### With ChurchCRM:
+- Extend existing Sunday School check-in
+- Use Groups feature for room assignments
+- API available for custom integrations
+
+### With ChurchApps:
+- Native integration — no additional work needed
+- Check-in data flows to attendance reports
+- Parent contact info already in system
+
+### With Jethro:
+- Use attendance tracking features
+- Export data for reporting
+- Roster integration for worker assignments
+
+### Standalone (DIY):
+- Design export format early (CSV/JSON)
+- Consider ChMS import for long-term storage
+- Keep family records synced manually or via API
+
+---
+
+*Last Updated: 2026-02-03 | Maintained by: church-tech-stack maintainers*

--- a/categories/volunteers/README.md
+++ b/categories/volunteers/README.md
@@ -1,0 +1,335 @@
+# Volunteer Scheduling & Management
+
+> Coordinating volunteers for services, events, and ministry teams.
+
+## Why It Matters
+
+Most churches run on volunteers. Coordinating dozens (or hundreds) of volunteers across multiple ministries, services, and events quickly becomes unmanageable with spreadsheets. Good volunteer scheduling software:
+
+- Prevents gaps in coverage (no more last-minute panic)
+- Respects volunteer availability and preferences
+- Enables easy substitutions and swaps
+- Sends reminders and notifications
+- Tracks serving history and preferences
+
+## The Landscape
+
+There are two main approaches:
+
+1. **Dedicated Volunteer Schedulers** — Purpose-built for recurring ministry schedules
+2. **General Scheduling Tools** — Adapted for church use (Doodle-style polling)
+
+---
+
+## OpenVolunteerPlatform
+
+**Status:** ⚠️ Maintenance Mode (last commit: 2022)
+
+**Skill Level:** Advanced
+
+**True Cost:**
+- Software: Free
+- Hosting: $10-30/mo VPS (requires 2GB+ RAM)
+- Setup Time: 8-12 hours
+- Ongoing Maintenance: 2-4 hours/month
+
+**What It Does:**
+Full-featured volunteer management platform originally built for crisis response (COVID-19). Includes role-based scheduling, real-time tracking via GraphQL subscriptions, automated reporting, and offline-capable mobile apps.
+
+**Why Churches Use It:**
+- Hierarchical organization structure (nations → regions → areas → cities)
+- Complex shift scheduling with capacity limits
+- Mobile apps with offline support
+- Real-time updates when volunteers check in/out
+- Built-in reporting and statistics
+
+**Installation:**
+- **Docker:** Available but complex (requires Keycloak, PostgreSQL, MQTT broker)
+- **Self-hosted:** See [deployment guide](https://github.com/aerogear/OpenVolunteerPlatform/blob/master/docs)
+
+**Architecture:**
+- Backend: Node.js/GraphQL with Graphback
+- Frontend: React with Offix (offline support)
+- Auth: Keycloak (SSO)
+- Real-time: MQTT broker for subscriptions
+
+**Caveats:**
+- Last significant update was 2022 — appears to be in maintenance mode
+- Overkill for small churches (< 50 volunteers)
+- Requires DevOps knowledge to deploy and maintain
+- Mobile apps need custom build for your instance
+
+**Links:**
+- GitHub: https://github.com/aerogear/OpenVolunteerPlatform
+- Docs: https://github.com/aerogear/OpenVolunteerPlatform/tree/master/docs
+
+---
+
+## Volunteer Planner (volunteer-planner.org)
+
+**Status:** ✅ Active (last commit: 2024)
+
+**Skill Level:** Intermediate
+
+**True Cost:**
+- Software: Free
+- Hosting: $5-15/mo VPS
+- Setup Time: 2-4 hours
+- Ongoing Maintenance: 1-2 hours/month
+
+**What It Does:**
+Django-based volunteer scheduling platform originally built for refugee aid coordination in Europe. Proven in production since 2015. Supports complex organizational hierarchies and shift-based scheduling.
+
+**Why Churches Use It:**
+- Battle-tested in high-volume environments (refugee aid)
+- Simple, clean interface for volunteers
+- Location-based hierarchy supports multi-site churches
+- Multi-language support (Transifex integration)
+- Self-contained — single Python application
+
+**Installation:**
+```bash
+# Using Docker (recommended)
+git clone https://github.com/coders4help/volunteer_planner.git
+cd volunteer_planner
+docker-compose up -d
+
+# Or manual setup
+git clone https://github.com/coders4help/volunteer_planner.git
+cd volunteer_planner
+virtualenv .venv
+source .venv/bin/activate
+pip install -r requirements/dev.txt
+./manage.py migrate
+./manage.py createsuperuser
+./manage.py runserver
+```
+
+**Features for Churches:**
+- Create organizations ("Children's Ministry", "Worship Team")
+- Add facilities/rooms ("Nursery", "Main Sanctuary")
+- Define shifts ("Sunday 9AM Service - Nursery")
+- Volunteers self-register and claim shifts
+- Automatic conflict detection
+- Email notifications
+
+**Caveats:**
+- European-focused ( GDPR-compliant by default)
+- UI is utilitarian, not polished
+- Email configuration required for notifications
+- No built-in check-in/check-out (scheduling only)
+
+**Links:**
+- GitHub: https://github.com/coders4help/volunteer_planner
+- Demo: https://volunteer-planner.org
+- Docs: https://github.com/coders4help/volunteer_planner/blob/develop/README_DOCKER.md
+
+---
+
+## Rallly
+
+**Status:** ✅ Very Active (last commit: 2025)
+
+**Skill Level:** Beginner to Intermediate
+
+**True Cost:**
+- Software: Free
+- Hosting: $5-10/mo VPS (or free tier on Railway/Render)
+- Setup Time: 30 minutes
+- Ongoing Maintenance: Minimal
+
+**What It Does:**
+Modern, Doodle-style scheduling tool for finding the best time for group meetings. While not built specifically for recurring volunteer schedules, it excels at event-based coordination and one-time scheduling needs.
+
+**Why Churches Use It:**
+- Beautiful, modern interface
+- No account required for participants
+- Works perfectly for: training sessions, one-time events, committee meetings
+- Self-hostable with Docker
+- Mobile-responsive
+- Automatic timezone handling
+
+**Installation (Docker):**
+```yaml
+version: "3"
+services:
+  rallly:
+    image: lukevella/rallly:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - DATABASE_URL=postgres://postgres:postgres@db:5432/rallly
+      - SECRET_KEY=your-secret-key-here
+    depends_on:
+      - db
+  db:
+    image: postgres:14
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=rallly
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:
+```
+
+**When to Use Rallly:**
+- Scheduling training sessions
+- Finding best time for volunteer meetings
+- Coordinating one-time events
+- Committee scheduling
+
+**When NOT to Use Rallly:**
+- Recurring weekly volunteer rotations (use Volunteer Planner or ChMS instead)
+- Complex shift management with capacity limits
+- Organizations with 100+ recurring positions
+
+**Links:**
+- GitHub: https://github.com/lukevella/rallly
+- Demo: https://rallly.co
+- Self-hosting docs: https://support.rallly.co/self-hosting
+
+---
+
+## ChurchApps (CHUMS/B1)
+
+**Status:** ✅ Very Active (last commit: 2025)
+
+**Skill Level:** Beginner
+
+**True Cost:**
+- Software: Free (open source)
+- Hosting: Cloud (free tier available) or self-hosted
+- Setup Time: 15 minutes (cloud) or 2-4 hours (self-hosted)
+- Ongoing Maintenance: Minimal (cloud) or 1-2 hours/month (self-hosted)
+
+**What It Does:**
+Full church management system with integrated volunteer scheduling, check-in, group management, and giving. The volunteer module includes scheduling, team management, and service planning.
+
+**Why Churches Use It:**
+- All-in-one solution (no integration needed)
+- Native mobile apps for iOS/Android
+- Check-in integration (volunteers and children)
+- Service planning with volunteer assignments
+- Free cloud tier for small churches
+- Active development and community
+
+**Deployment Options:**
+- **Cloud:** https://b1.church/ (free for small churches)
+- **Self-hosted:** Docker images available
+
+**Volunteer Features:**
+- Create volunteer teams/groups
+- Schedule volunteers for services
+- Self-check-in via mobile app
+- Swapping/declining shifts
+- Automated reminders
+- Integration with service planning
+
+**Caveats:**
+- Full ChMS — may be overkill if you only need volunteer scheduling
+- Self-hosted version requires multiple containers (API, web app, database)
+- Cloud version has feature limitations on free tier
+
+**Links:**
+- GitHub: https://github.com/ChurchApps/B1Admin
+- Website: https://b1.church/
+- Docs: https://churchapps.org/dev
+
+---
+
+## Comparison Matrix
+
+| Feature | OpenVolunteerPlatform | Volunteer Planner | Rallly | ChurchApps |
+|---------|----------------------|-------------------|--------|------------|
+| **Recurring Schedules** | ✅ | ✅ | ❌ | ✅ |
+| **Self-Serve Swap** | ✅ | ✅ | N/A | ✅ |
+| **Mobile Apps** | ✅ (build required) | ❌ | ✅ (web) | ✅ (native) |
+| **Check-in Integration** | ✅ | ❌ | ❌ | ✅ |
+| **Skill Level** | Advanced | Intermediate | Beginner | Beginner |
+| **Setup Time** | 8-12 hrs | 2-4 hrs | 30 min | 15 min (cloud) |
+| **Maintenance** | High | Medium | Low | Low/Medium |
+
+---
+
+## Recommendation by Church Size
+
+### Church Plant (< 50 people)
+**Use:** Google Sheets/Calendar or Rallly
+- Simple, free, no setup
+- For recurring schedules: shared Google Sheet with volunteer preferences
+- For events: Rallly cloud (free) or self-hosted
+
+### Small Church (50-200)
+**Use:** Volunteer Planner or ChurchApps Cloud
+- Volunteer Planner: If you want self-hosted control
+- ChurchApps Cloud: If you want all-in-one simplicity
+
+### Mid-Size Church (200-1000)
+**Use:** ChurchApps (self-hosted or cloud)
+- Native mobile apps for volunteers
+- Integrated with check-in and giving
+- Service planning integration
+
+### Large Church (1000+)
+**Use:** Evaluate OpenVolunteerPlatform (if maintained) or commercial solutions
+- May need custom development
+- Consider integration with existing ChMS
+
+---
+
+## DIY QR Code Check-In for Volunteers
+
+For churches wanting simple volunteer check-in without full scheduling:
+
+### Simple PHP/MySQL Solution
+```php
+// Basic structure for volunteer check-in
+// 1. Generate QR codes with volunteer IDs
+// 2. Scan at check-in station
+// 3. Log timestamp to database
+
+// Requirements:
+// - PHP 7.4+
+// - MySQL/MariaDB
+// - QR code library (endroid/qr-code)
+// - Mobile device with camera for scanning (or cheap USB scanner)
+
+// Estimated setup: 4-6 hours
+// Hosting: $5/mo shared hosting
+```
+
+### Open-Source QR Libraries:
+- **PHP:** `endroid/qr-code` (https://github.com/endroid/qr-code)
+- **Python:** `qrcode` library + Flask/FastAPI
+- **JavaScript:** `qrcodejs` (client-side generation)
+
+---
+
+## Integration Notes
+
+### With ChurchCRM:
+Use the Groups feature for volunteer teams, but it lacks scheduling. Export volunteer list to Volunteer Planner or use CalDAV integration for basic scheduling.
+
+### With Nextcloud:
+- Use **Calendar** for simple volunteer schedules
+- Use **Polls** app for finding best times (Rallly alternative)
+- Use **Forms** app for volunteer availability surveys
+
+### With ChurchApps:
+Native volunteer module included — no integration needed.
+
+---
+
+## Security Considerations
+
+- **Volunteer data is personal data** — GDPR/CCPA compliance matters
+- Use HTTPS for all volunteer-facing interfaces
+- Implement rate limiting on login endpoints
+- Regular backups of volunteer contact information
+- Consider data retention policies (delete old records)
+
+---
+
+*Last Updated: 2026-02-03 | Maintained by: church-tech-stack maintainers*

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -1,0 +1,43 @@
+# Docker Compose Deployments
+
+Ready-to-deploy Docker Compose stacks for self-hosting church software.
+
+## Choose Your Stack
+
+| Stack | Best For | RAM | What's Included |
+|-------|----------|-----|-----------------|
+| **[Starter](starter/)** | Most churches | 2GB | WordPress, ChurchCRM, Listmonk, Vaultwarden |
+| [Church Plant](church-plant/) | Minimal setup | 1-2GB | WordPress, ChurchCRM only |
+| [Small Church](small-church/) | Need file sharing | 2-4GB | + Nextcloud, Monitoring |
+| [Privacy-First](privacy-first/) | Full self-hosted | 4-8GB | + Jitsi, OnlyOffice, Backups |
+
+**Start with [Starter](starter/)** unless you have a specific reason for the others.
+
+## Quick Start
+
+```bash
+cd deployments/starter
+cp .env.example .env
+# Edit .env with your domains and passwords
+docker compose up -d
+```
+
+## What You Need
+
+- A VPS with 2GB+ RAM ($10-12/month from DigitalOcean, Linode, or Vultr)
+- A domain name pointed to your server
+- Basic command line familiarity (copy/paste is fine)
+
+## Stack Comparison
+
+| Feature | Starter | Church Plant | Small Church | Privacy-First |
+|---------|---------|--------------|--------------|---------------|
+| Website (WordPress) | ✅ | ✅ | ✅ | ✅ |
+| Member Management (ChurchCRM) | ✅ | ✅ | ✅ | ✅ |
+| Email Newsletters (Listmonk) | ✅ | ❌ | ✅ | ✅ |
+| Password Sharing (Vaultwarden) | ✅ | ❌ | ❌ | ✅ |
+| File Storage (Nextcloud) | ❌ | ❌ | ✅ | ✅ |
+| Video Calls (Jitsi) | ❌ | ❌ | ❌ | ✅ |
+| Document Editing (OnlyOffice) | ❌ | ❌ | ❌ | ✅ |
+| Monitoring (Uptime Kuma) | ❌ | ❌ | ✅ | ✅ |
+| Encrypted Backups (Duplicati) | ❌ | ❌ | ❌ | ✅ |

--- a/deployments/church-plant/.env.example
+++ b/deployments/church-plant/.env.example
@@ -1,0 +1,22 @@
+# Church Plant Stack Environment Variables
+
+# Domain Configuration
+# Point these subdomains to your server IP in DNS
+WORDPRESS_DOMAIN=www.yourchurch.com
+CHURCHCRM_DOMAIN=crm.yourchurch.com
+ADMINER_DOMAIN=db.yourchurch.com
+
+# Let's Encrypt Configuration
+ACME_EMAIL=admin@yourchurch.com
+
+# Database Passwords - CHANGE THESE TO STRONG PASSWORDS!
+# Generate strong passwords: openssl rand -base64 24
+WORDPRESS_DB_PASSWORD=change_this_password
+CHURCHCRM_DB_PASSWORD=change_this_password_too
+MYSQL_ROOT_PASSWORD=another_secure_password
+MYSQL_ROOT_PASSWORD_2=yet_another_secure_password
+
+# Adminer Basic Auth
+# Format: htpasswd -nb admin yourpassword | sed -e s/\$/\$\$/g
+# Default: admin / changeme
+ADMINER_AUTH=admin:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/

--- a/deployments/church-plant/README.md
+++ b/deployments/church-plant/README.md
@@ -1,0 +1,218 @@
+# Church Plant Stack
+
+> Zero-budget, minimal setup for new churches. One domain, one weekend.
+
+## What's Included
+
+| Function | Tool | Why |
+|----------|------|-----|
+| **Website** | WordPress | Familiar, plugin ecosystem, easy themes |
+| **ChMS** | ChurchCRM | Member tracking, groups, basic check-in |
+| **Database** | Adminer | Easy database management without command line |
+| **Proxy/SSL** | Traefik | Automatic HTTPS, simple routing |
+
+## System Requirements
+
+- **Server:** VPS with 1GB RAM (2GB recommended), 20GB storage
+- **OS:** Ubuntu 22.04 LTS or Debian 12
+- **Domain:** One domain with DNS access
+- **Skills:** Basic Linux command line, Docker familiarity helpful
+
+## Quick Start
+
+### 1. Prepare Your Server
+
+```bash
+# Update system
+sudo apt update && sudo apt upgrade -y
+
+# Install Docker
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+newgrp docker
+
+# Install Docker Compose
+sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+
+# Create directory
+mkdir -p ~/church-plant && cd ~/church-plant
+```
+
+### 2. Download Stack Files
+
+```bash
+# Download docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/church-tech-stack/main/stacks/church-plant/docker-compose.yml
+
+# Download environment template
+curl -o .env.example https://raw.githubusercontent.com/church-tech-stack/main/stacks/church-plant/.env.example
+cp .env.example .env
+```
+
+### 3. Configure Environment
+
+Edit `.env`:
+
+```bash
+# Your domain names (must point to server IP)
+WORDPRESS_DOMAIN=www.yourchurch.com
+CHURCHCRM_DOMAIN=crm.yourchurch.com
+ADMINER_DOMAIN=db.yourchurch.com
+
+# Let's Encrypt email (for SSL certificates)
+ACME_EMAIL=you@yourchurch.com
+
+# Database passwords - CHANGE THESE!
+WORDPRESS_DB_PASSWORD=your_secure_password_1
+CHURCHCRM_DB_PASSWORD=your_secure_password_2
+MYSQL_ROOT_PASSWORD=your_secure_root_password
+MYSQL_ROOT_PASSWORD_2=your_secure_root_password_2
+
+# Adminer login (user: admin, password: changeme)
+# Generate with: htpasswd -nb admin yourpassword | sed -e s/\$/\$\$/g
+ADMINER_AUTH=admin:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/
+```
+
+### 4. Start the Stack
+
+```bash
+docker-compose up -d
+```
+
+### 5. Complete Setup
+
+**WordPress:**
+1. Visit `https://www.yourchurch.com`
+2. Complete WordPress setup wizard
+3. Install a church theme (recommend: "Church" or "Faith")
+4. Essential plugins: 
+   - "Sermon Manager" for sermons
+   - "The Events Calendar" for events
+   - "WP Mail SMTP" for email
+
+**ChurchCRM:**
+1. Visit `https://crm.yourchurch.com`
+2. Create admin account
+3. Complete initial setup wizard
+4. Configure email settings (use WP Mail SMTP credentials)
+5. Import members or add manually
+
+## Maintenance
+
+### Backup
+
+Create `backup.sh`:
+
+```bash
+#!/bin/bash
+DATE=$(date +%Y%m%d_%H%M%S)
+BACKUP_DIR="$HOME/backups"
+mkdir -p $BACKUP_DIR
+
+# Backup WordPress files
+docker run --rm -v church-plant_wordpress-data:/data -v $BACKUP_DIR:/backup alpine tar czf /backup/wordpress_$DATE.tar.gz -C /data .
+
+# Backup ChurchCRM files
+docker run --rm -v church-plant_churchcrm-data:/data -v $BACKUP_DIR:/backup alpine tar czf /backup/churchcrm_$DATE.tar.gz -C /data .
+
+# Backup databases
+docker exec church-plant-wordpress-db mysqldump -u root -p${MYSQL_ROOT_PASSWORD} wordpress > $BACKUP_DIR/wordpress_db_$DATE.sql
+docker exec church-plant-churchcrm-db mysqldump -u root -p${MYSQL_ROOT_PASSWORD_2} churchcrm > $BACKUP_DIR/churchcrm_db_$DATE.sql
+
+# Keep only last 7 days
+find $BACKUP_DIR -name "*.tar.gz" -mtime +7 -delete
+find $BACKUP_DIR -name "*.sql" -mtime +7 -delete
+
+echo "Backup completed: $DATE"
+```
+
+Add to crontab:
+```bash
+0 2 * * * /home/youruser/church-plant/backup.sh >> /var/log/church-backup.log 2>&1
+```
+
+### Updates
+
+```bash
+# Update containers
+docker-compose pull
+docker-compose up -d
+
+# Update WordPress plugins (via admin panel)
+# Update ChurchCRM (via built-in updater)
+```
+
+## Troubleshooting
+
+### Can't access sites
+```bash
+# Check containers are running
+docker-compose ps
+
+# Check logs
+docker-compose logs traefik
+docker-compose logs wordpress
+
+# Verify DNS
+dig +short www.yourchurch.com
+```
+
+### SSL certificate issues
+```bash
+# View Traefik logs
+docker-compose logs traefik
+
+# Force renewal (delete acme.json and restart)
+docker-compose down
+rm letsencrypt/acme.json
+docker-compose up -d
+```
+
+### Database connection errors
+```bash
+# Verify databases are healthy
+docker-compose ps
+
+# Check database logs
+docker-compose logs wordpress-db
+docker-compose logs churchcrm-db
+```
+
+## Security Notes
+
+1. **Change default passwords immediately**
+2. **Enable WordPress security plugin** (Wordfence or similar)
+3. **Keep backups offsite** (rsync to another server or S3)
+4. **Configure firewall:**
+   ```bash
+   sudo ufw allow 22/tcp
+   sudo ufw allow 80/tcp
+   sudo ufw allow 443/tcp
+   sudo ufw enable
+   ```
+5. **Enable automatic security updates:**
+   ```bash
+   sudo apt install unattended-upgrades
+   sudo dpkg-reconfigure unattended-upgrades
+   ```
+
+## Migration Path
+
+When ready to upgrade to Small Church Stack:
+
+1. Export data from WordPress (Tools → Export)
+2. Export ChurchCRM database
+3. Deploy Small Church Stack on larger server
+4. Import data
+5. Redirect domains
+
+## Support
+
+- WordPress docs: https://wordpress.org/support/
+- ChurchCRM docs: https://github.com/ChurchCRM/CRM/wiki
+- Traefik docs: https://doc.traefik.io/traefik/
+
+---
+
+*Stack Version: 1.0 | Last Updated: 2026-02-03*

--- a/deployments/church-plant/docker-compose.yml
+++ b/deployments/church-plant/docker-compose.yml
@@ -1,0 +1,143 @@
+version: "3.8"
+
+# Church Plant Stack - Minimal Setup
+# For new churches with no budget and a volunteer running tech
+# 
+# What's Included:
+# - WordPress (website)
+# - ChurchCRM (basic ChMS)
+# - Adminer (database management)
+#
+# Requirements:
+# - 1GB RAM minimum, 2GB recommended
+# - Single domain with subdomains or paths
+# - Docker and Docker Compose installed
+
+services:
+  # Traefik reverse proxy - handles SSL and routing
+  traefik:
+    image: traefik:v2.10
+    container_name: church-plant-traefik
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.letsencrypt.acme.tlschallenge=true"
+      - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL:-admin@example.com}"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./letsencrypt:/letsencrypt
+    networks:
+      - church-plant
+    restart: unless-stopped
+
+  # WordPress - Church website
+  wordpress:
+    image: wordpress:latest
+    container_name: church-plant-wordpress
+    environment:
+      WORDPRESS_DB_HOST: wordpress-db
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: ${WORDPRESS_DB_PASSWORD:-changeme}
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - wordpress-data:/var/www/html
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.wordpress.rule=Host(`${WORDPRESS_DOMAIN:-church.example.com}`)"
+      - "traefik.http.routers.wordpress.entrypoints=websecure"
+      - "traefik.http.routers.wordpress.tls.certresolver=letsencrypt"
+      - "traefik.http.services.wordpress.loadbalancer.server.port=80"
+    networks:
+      - church-plant
+    depends_on:
+      - wordpress-db
+    restart: unless-stopped
+
+  # WordPress Database
+  wordpress-db:
+    image: mysql:8.0
+    container_name: church-plant-wordpress-db
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-changeme}
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: ${WORDPRESS_DB_PASSWORD:-changeme}
+    volumes:
+      - wordpress-db-data:/var/lib/mysql
+    networks:
+      - church-plant
+    restart: unless-stopped
+
+  # ChurchCRM - Church Management
+  churchcrm:
+    image: churchcrm/crm:latest
+    container_name: church-plant-churchcrm
+    environment:
+      CRM_DB_HOST: churchcrm-db
+      CRM_DB_NAME: churchcrm
+      CRM_DB_USER: churchcrm
+      CRM_DB_PASS: ${CHURCHCRM_DB_PASSWORD:-changeme}
+      CRM_DB_PORT: "3306"
+    volumes:
+      - churchcrm-data:/var/www/churchcrm
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.churchcrm.rule=Host(`${CHURCHCRM_DOMAIN:-crm.church.example.com}`)"
+      - "traefik.http.routers.churchcrm.entrypoints=websecure"
+      - "traefik.http.routers.churchcrm.tls.certresolver=letsencrypt"
+      - "traefik.http.services.churchcrm.loadbalancer.server.port=80"
+    networks:
+      - church-plant
+    depends_on:
+      - churchcrm-db
+    restart: unless-stopped
+
+  # ChurchCRM Database
+  churchcrm-db:
+    image: mariadb:10.6
+    container_name: church-plant-churchcrm-db
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD_2:-changeme2}
+      MYSQL_DATABASE: churchcrm
+      MYSQL_USER: churchcrm
+      MYSQL_PASSWORD: ${CHURCHCRM_DB_PASSWORD:-changeme}
+    volumes:
+      - churchcrm-db-data:/var/lib/mysql
+    networks:
+      - church-plant
+    restart: unless-stopped
+
+  # Adminer - Database management (optional)
+  adminer:
+    image: adminer:latest
+    container_name: church-plant-adminer
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.adminer.rule=Host(`${ADMINER_DOMAIN:-db.church.example.com}`)"
+      - "traefik.http.routers.adminer.entrypoints=websecure"
+      - "traefik.http.routers.adminer.tls.certresolver=letsencrypt"
+      - "traefik.http.services.adminer.loadbalancer.server.port=8080"
+      # Basic auth protection
+      - "traefik.http.middlewares.adminer-auth.basicauth.users=${ADMINER_AUTH:-admin:$$apr1$$H6uskkkW$$IgXLP6ewTrSuBkTrqE8wj/}"
+      - "traefik.http.routers.adminer.middlewares=adminer-auth"
+    networks:
+      - church-plant
+    restart: unless-stopped
+
+networks:
+  church-plant:
+    driver: bridge
+
+volumes:
+  wordpress-data:
+  wordpress-db-data:
+  churchcrm-data:
+  churchcrm-db-data:

--- a/deployments/privacy-first/.env.example
+++ b/deployments/privacy-first/.env.example
@@ -1,0 +1,64 @@
+# Privacy-First Stack Environment Variables
+
+# Domain Configuration
+WORDPRESS_DOMAIN=www.yourchurch.com
+CHURCHCRM_DOMAIN=crm.yourchurch.com
+NEXTCLOUD_DOMAIN=cloud.yourchurch.com
+ONLYOFFICE_DOMAIN=office.yourchurch.com
+LISTMONK_DOMAIN=news.yourchurch.com
+JITSI_DOMAIN=meet.yourchurch.com
+VAULTWARDEN_DOMAIN=pass.yourchurch.com
+UPTIME_DOMAIN=status.yourchurch.com
+DUPLICATI_DOMAIN=backup.yourchurch.com
+
+# Let's Encrypt
+ACME_EMAIL=admin@yourchurch.com
+
+# Timezone
+TZ=America/New_York
+
+# Database Passwords - GENERATE STRONG PASSWORDS!
+WORDPRESS_DB_PASSWORD=change_me
+CHURCHCRM_DB_PASSWORD=change_me_2
+NEXTCLOUD_DB_PASSWORD=change_me_3
+MYSQL_ROOT_PASSWORD=root_password_1
+MYSQL_ROOT_PASSWORD_2=root_password_2
+MYSQL_ROOT_PASSWORD_3=root_password_3
+LISTMONK_DB_PASSWORD=change_me_4
+
+# Nextcloud Admin
+NEXTCLOUD_ADMIN_USER=admin
+NEXTCLOUD_ADMIN_PASSWORD=change_me_admin
+
+# Listmonk Admin
+LISTMONK_ADMIN_USER=admin
+LISTMONK_ADMIN_PASSWORD=change_me_listmonk
+
+# OnlyOffice JWT Secret
+ONLYOFFICE_JWT_SECRET=change_me_jwt
+
+# Jitsi Configuration
+JITSI_APP_ID=jitsi
+JITSI_APP_SECRET=change_me_jitsi_secret
+JITSI_ETHERPAD_URL=http://etherpad.meet.jitsi:9001
+
+# Vaultwarden
+VAULTWARDEN_SIGNUPS=false
+VAULTWARDEN_ADMIN_TOKEN=change_me_admin_token
+
+# SMTP Configuration (from Mail-in-a-Box)
+SMTP_HOST=mail.yourchurch.com
+SMTP_PORT=587
+SMTP_SECURE=starttls
+SMTP_USER=noreply@yourchurch.com
+SMTP_PASSWORD=change_me_smtp
+MAIL_FROM=noreply
+MAIL_DOMAIN=yourchurch.com
+
+# Watchtower Notifications
+WATCHTOWER_EMAIL_FROM=admin@yourchurch.com
+WATCHTOWER_EMAIL_TO=admin@yourchurch.com
+WATCHTOWER_EMAIL_SERVER=smtp.gmail.com
+WATCHTOWER_EMAIL_PORT=587
+WATCHTOWER_EMAIL_USER=
+WATCHTOWER_EMAIL_PASSWORD=

--- a/deployments/privacy-first/README.md
+++ b/deployments/privacy-first/README.md
@@ -1,0 +1,127 @@
+# Privacy-First Stack
+
+> Fully self-hosted church technology stack for data sovereignty and privacy.
+
+## Philosophy
+
+This stack is for churches that:
+- Believe member data belongs to the church, not third parties
+- Want to avoid vendor lock-in and subscription fees
+- Have (or can develop) technical expertise
+- Value privacy and security
+
+**What "Privacy-First" Means:**
+- All data stored on your servers
+- No third-party analytics or tracking
+- Open source throughout
+- Encrypted backups you control
+- Self-hosted email capability
+
+## What's Included
+
+| Function | Tool | Purpose |
+|----------|------|---------|
+| **Website** | WordPress | Content, sermons, events |
+| **ChMS** | ChurchCRM | Membership, giving, check-in |
+| **Files/Collaboration** | Nextcloud | Documents, calendars, contacts |
+| **Document Editing** | OnlyOffice | Collaborative document editing |
+| **Email Lists** | Listmonk | Newsletters, announcements |
+| **Email Server** | Mail-in-a-Box | Self-hosted email (separate VM) |
+| **Video Conferencing** | Jitsi Meet | Online meetings, Bible studies |
+| **Password Management** | Vaultwarden | Team password vault |
+| **Monitoring** | Uptime Kuma | Service health monitoring |
+| **Backups** | Duplicati | Encrypted, deduplicated backups |
+
+## System Requirements
+
+### Main Server
+- **VPS/Dedicated:** 4GB RAM minimum, 8GB recommended
+- **Storage:** 100GB minimum (more for file storage)
+- **OS:** Ubuntu 22.04 LTS
+- **Domain:** Main domain + multiple subdomains
+- **IP:** Static IP address
+
+### Email Server (Mail-in-a-Box)
+- **Separate VPS:** 1GB RAM, 25GB storage
+- **OS:** Ubuntu 22.04 LTS
+- **Domain:** mail.yourdomain.com
+- **IP:** Static IP with good reputation
+
+## Quick Start
+
+### Phase 1: Server Preparation
+
+```bash
+# Update system
+sudo apt update && sudo apt upgrade -y
+
+# Install Docker
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+newgrp docker
+
+# Install Docker Compose
+sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+
+# Set up firewall
+sudo ufw allow 22/tcp
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw allow 10000/udp  # Jitsi
+sudo ufw --force enable
+```
+
+### Phase 2: DNS Configuration
+
+Configure these DNS records pointing to your server IP:
+- www.yourchurch.com (WordPress)
+- crm.yourchurch.com (ChurchCRM)
+- cloud.yourchurch.com (Nextcloud)
+- office.yourchurch.com (OnlyOffice)
+- news.yourchurch.com (Listmonk)
+- meet.yourchurch.com (Jitsi)
+- pass.yourchurch.com (Vaultwarden)
+- status.yourchurch.com (Uptime Kuma)
+- backup.yourchurch.com (Duplicati)
+
+### Phase 3: Deploy
+
+```bash
+# Download and configure
+curl -o docker-compose.yml https://raw.githubusercontent.com/church-tech-stack/main/stacks/privacy-first/docker-compose.yml
+curl -o .env.example https://raw.githubusercontent.com/church-tech-stack/main/stacks/privacy-first/.env.example
+cp .env.example .env
+
+# Edit .env with your domains and secure passwords
+nano .env
+
+# Start services
+docker-compose up -d
+```
+
+### Phase 4: Configure Each Service
+
+1. **Nextcloud** - Enable Calendar, Contacts, Deck apps; connect OnlyOffice
+2. **ChurchCRM** - Import members, set up groups, configure check-in
+3. **Listmonk** - Configure SMTP, create mailing lists, import subscribers
+4. **Jitsi** - Test video calls, create persistent rooms
+5. **Vaultwarden** - Enable 2FA, create organization, invite users
+6. **Duplicati** - Set up encrypted backups to S3/B2
+
+## Security Best Practices
+
+- Use strong, unique passwords for all services
+- Enable 2FA on all admin accounts
+- Configure fail2ban on the host
+- Regular security updates
+- Encrypted offsite backups
+- Monitor Uptime Kuma alerts
+
+## Support Resources
+
+See individual service documentation for detailed help.
+
+---
+
+*Stack Version: 1.0 | Last Updated: 2026-02-03*

--- a/deployments/privacy-first/docker-compose.yml
+++ b/deployments/privacy-first/docker-compose.yml
@@ -1,0 +1,457 @@
+version: "3.8"
+
+# Privacy-First Stack - Full Self-Hosted Setup
+# For churches prioritizing data sovereignty and privacy
+#
+# What's Included:
+# - WordPress (website)
+# - ChurchCRM (ChMS)
+# - Nextcloud + OnlyOffice (files, docs, calendar)
+# - Listmonk (email newsletters)
+# - Jitsi Meet (video conferencing)
+# - Vaultwarden (password management)
+# - Uptime Kuma (monitoring)
+# - Duplicati (encrypted backups)
+#
+# Requirements:
+# - 4GB RAM minimum, 8GB recommended
+# - 100GB+ storage
+# - Multiple subdomains
+# - Docker and Docker Compose installed
+# - Separate Mail-in-a-Box server for email
+
+services:
+  # Traefik reverse proxy - handles SSL and routing
+  traefik:
+    image: traefik:v2.10
+    container_name: privacy-first-traefik
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.letsencrypt.acme.tlschallenge=true"
+      - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL:-admin@example.com}"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
+      - "--ping=true"
+      - "--accesslog=true"
+      - "--accesslog.filepath=/var/log/traefik/access.log"
+    ports:
+      - "80:80"
+      - "443:443"
+      - "10000:10000/udp"  # Jitsi video
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./letsencrypt:/letsencrypt
+      - ./traefik-logs:/var/log/traefik
+    networks:
+      - privacy-first
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # WordPress - Church website
+  wordpress:
+    image: wordpress:latest
+    container_name: privacy-first-wordpress
+    environment:
+      WORDPRESS_DB_HOST: wordpress-db
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: ${WORDPRESS_DB_PASSWORD:-changeme}
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - wordpress-data:/var/www/html
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.wordpress.rule=Host(`${WORDPRESS_DOMAIN:-www.example.com}`)"
+      - "traefik.http.routers.wordpress.entrypoints=websecure"
+      - "traefik.http.routers.wordpress.tls.certresolver=letsencrypt"
+      - "traefik.http.services.wordpress.loadbalancer.server.port=80"
+      # Security headers
+      - "traefik.http.middlewares.wordpress-headers.headers.stsSeconds=31536000"
+      - "traefik.http.middlewares.wordpress-headers.headers.stsIncludeSubdomains=true"
+      - "traefik.http.routers.wordpress.middlewares=wordpress-headers"
+    networks:
+      - privacy-first
+    depends_on:
+      - wordpress-db
+    restart: unless-stopped
+
+  wordpress-db:
+    image: mysql:8.0
+    container_name: privacy-first-wordpress-db
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-changeme}
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: ${WORDPRESS_DB_PASSWORD:-changeme}
+    volumes:
+      - wordpress-db-data:/var/lib/mysql
+    networks:
+      - privacy-first
+    restart: unless-stopped
+    command: --default-authentication-plugin=mysql_native_password
+
+  # ChurchCRM - Church Management
+  churchcrm:
+    image: churchcrm/crm:latest
+    container_name: privacy-first-churchcrm
+    environment:
+      CRM_DB_HOST: churchcrm-db
+      CRM_DB_NAME: churchcrm
+      CRM_DB_USER: churchcrm
+      CRM_DB_PASS: ${CHURCHCRM_DB_PASSWORD:-changeme}
+    volumes:
+      - churchcrm-data:/var/www/churchcrm
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.churchcrm.rule=Host(`${CHURCHCRM_DOMAIN:-crm.example.com}`)"
+      - "traefik.http.routers.churchcrm.entrypoints=websecure"
+      - "traefik.http.routers.churchcrm.tls.certresolver=letsencrypt"
+      - "traefik.http.services.churchcrm.loadbalancer.server.port=80"
+    networks:
+      - privacy-first
+    depends_on:
+      - churchcrm-db
+    restart: unless-stopped
+
+  churchcrm-db:
+    image: mariadb:10.6
+    container_name: privacy-first-churchcrm-db
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD_2:-changeme2}
+      MYSQL_DATABASE: churchcrm
+      MYSQL_USER: churchcrm
+      MYSQL_PASSWORD: ${CHURCHCRM_DB_PASSWORD:-changeme}
+    volumes:
+      - churchcrm-db-data:/var/lib/mysql
+    networks:
+      - privacy-first
+    restart: unless-stopped
+
+  # Nextcloud - File storage and collaboration
+  nextcloud:
+    image: nextcloud:latest
+    container_name: privacy-first-nextcloud
+    environment:
+      MYSQL_HOST: nextcloud-db
+      MYSQL_DATABASE: nextcloud
+      MYSQL_USER: nextcloud
+      MYSQL_PASSWORD: ${NEXTCLOUD_DB_PASSWORD:-changeme}
+      NEXTCLOUD_ADMIN_USER: ${NEXTCLOUD_ADMIN_USER:-admin}
+      NEXTCLOUD_ADMIN_PASSWORD: ${NEXTCLOUD_ADMIN_PASSWORD:-changeme}
+      NEXTCLOUD_TRUSTED_DOMAINS: ${NEXTCLOUD_DOMAIN:-cloud.example.com}
+      REDIS_HOST: nextcloud-redis
+    volumes:
+      - nextcloud-data:/var/www/html
+      - nextcloud-apps:/var/www/html/custom_apps
+      - nextcloud-config:/var/www/html/config
+      - nextcloud-files:/var/www/html/data
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.nextcloud.rule=Host(`${NEXTCLOUD_DOMAIN:-cloud.example.com}`)"
+      - "traefik.http.routers.nextcloud.entrypoints=websecure"
+      - "traefik.http.routers.nextcloud.tls.certresolver=letsencrypt"
+      - "traefik.http.services.nextcloud.loadbalancer.server.port=80"
+      # WebDAV fix
+      - "traefik.http.middlewares.nextcloud-dav.replacepathregex.regex=^/.well-known/(card|cal)dav"
+      - "traefik.http.middlewares.nextcloud-dav.replacepathregex.replacement=/remote.php/dav/"
+      - "traefik.http.routers.nextcloud.middlewares=nextcloud-dav"
+    networks:
+      - privacy-first
+    depends_on:
+      - nextcloud-db
+      - nextcloud-redis
+    restart: unless-stopped
+
+  nextcloud-db:
+    image: mariadb:10.6
+    container_name: privacy-first-nextcloud-db
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD_3:-changeme3}
+      MYSQL_DATABASE: nextcloud
+      MYSQL_USER: nextcloud
+      MYSQL_PASSWORD: ${NEXTCLOUD_DB_PASSWORD:-changeme}
+    volumes:
+      - nextcloud-db-data:/var/lib/mysql
+    networks:
+      - privacy-first
+    restart: unless-stopped
+
+  nextcloud-redis:
+    image: redis:alpine
+    container_name: privacy-first-nextcloud-redis
+    volumes:
+      - nextcloud-redis-data:/data
+    networks:
+      - privacy-first
+    restart: unless-stopped
+
+  # OnlyOffice - Document editing
+  onlyoffice:
+    image: onlyoffice/documentserver:latest
+    container_name: privacy-first-onlyoffice
+    environment:
+      JWT_SECRET: ${ONLYOFFICE_JWT_SECRET:-changeme}
+      JWT_ENABLED: "true"
+    volumes:
+      - onlyoffice-data:/var/www/onlyoffice/Data
+      - onlyoffice-logs:/var/log/onlyoffice
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.onlyoffice.rule=Host(`${ONLYOFFICE_DOMAIN:-office.example.com}`)"
+      - "traefik.http.routers.onlyoffice.entrypoints=websecure"
+      - "traefik.http.routers.onlyoffice.tls.certresolver=letsencrypt"
+      - "traefik.http.services.onlyoffice.loadbalancer.server.port=80"
+    networks:
+      - privacy-first
+    restart: unless-stopped
+
+  # Listmonk - Email newsletters
+  listmonk:
+    image: listmonk/listmonk:latest
+    container_name: privacy-first-listmonk
+    environment:
+      LISTMONK_app__address: "0.0.0.0:9000"
+      LISTMONK_app__admin_username: ${LISTMONK_ADMIN_USER:-admin}
+      LISTMONK_app__admin_password: ${LISTMONK_ADMIN_PASSWORD:-changeme}
+      LISTMONK_db__host: listmonk-db
+      LISTMONK_db__port: "5432"
+      LISTMONK_db__user: listmonk
+      LISTMONK_db__password: ${LISTMONK_DB_PASSWORD:-changeme}
+      LISTMONK_db__database: listmonk
+      LISTMONK_db__ssl_mode: disable
+      TZ: ${TZ:-America/New_York}
+    volumes:
+      - listmonk-data:/listmonk/uploads
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.listmonk.rule=Host(`${LISTMONK_DOMAIN:-news.example.com}`)"
+      - "traefik.http.routers.listmonk.entrypoints=websecure"
+      - "traefik.http.routers.listmonk.tls.certresolver=letsencrypt"
+      - "traefik.http.services.listmonk.loadbalancer.server.port=9000"
+    networks:
+      - privacy-first
+    depends_on:
+      - listmonk-db
+    restart: unless-stopped
+    command: [sh, -c, "./listmonk --install --idempotent && ./listmonk"]
+
+  listmonk-db:
+    image: postgres:15-alpine
+    container_name: privacy-first-listmonk-db
+    environment:
+      POSTGRES_PASSWORD: ${LISTMONK_DB_PASSWORD:-changeme}
+      POSTGRES_USER: listmonk
+      POSTGRES_DB: listmonk
+    volumes:
+      - listmonk-db-data:/var/lib/postgresql/data
+    networks:
+      - privacy-first
+    restart: unless-stopped
+
+  # Jitsi Meet - Video conferencing
+  jitsi-web:
+    image: jitsi/web:stable
+    container_name: privacy-first-jitsi-web
+    environment:
+      - PUBLIC_URL=https://${JITSI_DOMAIN:-meet.example.com}
+      - TZ=${TZ:-America/New_York}
+      - ENABLE_COLIBRI_WEBSOCKET=true
+      - ENABLE_XMPP_WEBSOCKET=true
+    volumes:
+      - jitsi-web-config:/config
+      - jitsi-transcripts:/usr/share/jitsi-meet/transcripts
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.jitsi.rule=Host(`${JITSI_DOMAIN:-meet.example.com}`)"
+      - "traefik.http.routers.jitsi.entrypoints=websecure"
+      - "traefik.http.routers.jitsi.tls.certresolver=letsencrypt"
+      - "traefik.http.services.jitsi.loadbalancer.server.port=80"
+    networks:
+      privacy-first:
+        aliases:
+          - meet.jitsi
+    depends_on:
+      - jitsi-prosody
+    restart: unless-stopped
+
+  jitsi-prosody:
+    image: jitsi/prosody:stable
+    container_name: privacy-first-jitsi-prosody
+    environment:
+      - PUBLIC_URL=https://${JITSI_DOMAIN:-meet.example.com}
+      - XMPP_DOMAIN=meet.jitsi
+      - XMPP_AUTH_DOMAIN=auth.meet.jitsi
+      - XMPP_MUC_DOMAIN=muc.meet.jitsi
+      - XMPP_INTERNAL_MUC_DOMAIN=internal-muc.meet.jitsi
+      - TZ=${TZ:-America/New_York}
+    volumes:
+      - jitsi-prosody-config:/config
+      - jitsi-prosody-plugins:/prosody-plugins-custom
+    networks:
+      privacy-first:
+        aliases:
+          - xmpp.meet.jitsi
+    restart: unless-stopped
+
+  jitsi-jicofo:
+    image: jitsi/jicofo:stable
+    container_name: privacy-first-jitsi-jicofo
+    environment:
+      - XMPP_DOMAIN=meet.jitsi
+      - XMPP_AUTH_DOMAIN=auth.meet.jitsi
+      - XMPP_MUC_DOMAIN=muc.meet.jitsi
+      - XMPP_INTERNAL_MUC_DOMAIN=internal-muc.meet.jitsi
+      - TZ=${TZ:-America/New_York}
+    volumes:
+      - jitsi-jicofo-config:/config
+    networks:
+      - privacy-first
+    depends_on:
+      - jitsi-prosody
+    restart: unless-stopped
+
+  jitsi-jvb:
+    image: jitsi/jvb:stable
+    container_name: privacy-first-jitsi-jvb
+    environment:
+      - PUBLIC_URL=https://${JITSI_DOMAIN:-meet.example.com}
+      - XMPP_AUTH_DOMAIN=auth.meet.jitsi
+      - XMPP_INTERNAL_MUC_DOMAIN=internal-muc.meet.jitsi
+      - JVB_PORT=10000
+      - JVB_STUN_SERVERS=meet-jit-si-turnrelay.jitsi.net:443
+      - TZ=${TZ:-America/New_York}
+    volumes:
+      - jitsi-jvb-config:/config
+    ports:
+      - "10000:10000/udp"
+    networks:
+      - privacy-first
+    depends_on:
+      - jitsi-prosody
+    restart: unless-stopped
+
+  # Vaultwarden - Password management
+  vaultwarden:
+    image: vaultwarden/server:latest
+    container_name: privacy-first-vaultwarden
+    environment:
+      SIGNUPS_ALLOWED: ${VAULTWARDEN_SIGNUPS:-false}
+      ADMIN_TOKEN: ${VAULTWARDEN_ADMIN_TOKEN:-changeme}
+      DOMAIN: https://${VAULTWARDEN_DOMAIN:-pass.example.com}
+      SMTP_HOST: ${SMTP_HOST:-mail.example.com}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_SECURITY: ${SMTP_SECURE:-starttls}
+      SMTP_USERNAME: ${SMTP_USER}
+      SMTP_PASSWORD: ${SMTP_PASSWORD}
+      SMTP_FROM: noreply@${MAIL_DOMAIN:-example.com}
+    volumes:
+      - vaultwarden-data:/data
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.vaultwarden.rule=Host(`${VAULTWARDEN_DOMAIN:-pass.example.com}`)"
+      - "traefik.http.routers.vaultwarden.entrypoints=websecure"
+      - "traefik.http.routers.vaultwarden.tls.certresolver=letsencrypt"
+      - "traefik.http.services.vaultwarden.loadbalancer.server.port=80"
+    networks:
+      - privacy-first
+    restart: unless-stopped
+
+  # Uptime Kuma - Monitoring
+  uptime-kuma:
+    image: louislam/uptime-kuma:latest
+    container_name: privacy-first-uptime-kuma
+    volumes:
+      - uptime-kuma-data:/app/data
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.uptime-kuma.rule=Host(`${UPTIME_DOMAIN:-status.example.com}`)"
+      - "traefik.http.routers.uptime-kuma.entrypoints=websecure"
+      - "traefik.http.routers.uptime-kuma.tls.certresolver=letsencrypt"
+      - "traefik.http.services.uptime-kuma.loadbalancer.server.port=3001"
+    networks:
+      - privacy-first
+    restart: unless-stopped
+
+  # Duplicati - Encrypted backups
+  duplicati:
+    image: lscr.io/linuxserver/duplicati:latest
+    container_name: privacy-first-duplicati
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=${TZ:-America/New_York}
+    volumes:
+      - duplicati-config:/config
+      - duplicati-backups:/backups
+      # Mount all data volumes for backup access
+      - wordpress-data:/source/wordpress:ro
+      - churchcrm-data:/source/churchcrm:ro
+      - nextcloud-files:/source/nextcloud:ro
+      - vaultwarden-data:/source/vaultwarden:ro
+      - listmonk-data:/source/listmonk:ro
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.duplicati.rule=Host(`${DUPLICATI_DOMAIN:-backup.example.com}`)"
+      - "traefik.http.routers.duplicati.entrypoints=websecure"
+      - "traefik.http.routers.duplicati.tls.certresolver=letsencrypt"
+      - "traefik.http.services.duplicati.loadbalancer.server.port=8200"
+    networks:
+      - privacy-first
+    restart: unless-stopped
+
+  # Watchtower - Automatic updates (with caution)
+  watchtower:
+    image: containrrr/watchtower:latest
+    container_name: privacy-first-watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - WATCHTOWER_CLEANUP=true
+      - WATCHTOWER_POLL_INTERVAL=604800  # Weekly (7 days)
+      - WATCHTOWER_NOTIFICATIONS=email
+      - WATCHTOWER_NOTIFICATION_EMAIL_FROM=${WATCHTOWER_EMAIL_FROM:-admin@example.com}
+      - WATCHTOWER_NOTIFICATION_EMAIL_TO=${WATCHTOWER_EMAIL_TO:-admin@example.com}
+      - WATCHTOWER_NOTIFICATION_EMAIL_SERVER=${WATCHTOWER_EMAIL_SERVER:-smtp.example.com}
+      - WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT=${WATCHTOWER_EMAIL_PORT:-587}
+      - WATCHTOWER_NOTIFICATION_EMAIL_SERVER_USER=${WATCHTOWER_EMAIL_USER}
+      - WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD=${WATCHTOWER_EMAIL_PASSWORD}
+      # Only update during maintenance window (Sunday 2-4 AM)
+      - WATCHTOWER_SCHEDULE=0 0 2 * * 0
+    restart: unless-stopped
+
+networks:
+  privacy-first:
+    driver: bridge
+
+volumes:
+  wordpress-data:
+  wordpress-db-data:
+  churchcrm-data:
+  churchcrm-db-data:
+  nextcloud-data:
+  nextcloud-apps:
+  nextcloud-config:
+  nextcloud-files:
+  nextcloud-db-data:
+  nextcloud-redis-data:
+  onlyoffice-data:
+  onlyoffice-logs:
+  listmonk-data:
+  listmonk-db-data:
+  jitsi-web-config:
+  jitsi-transcripts:
+  jitsi-prosody-config:
+  jitsi-prosody-plugins:
+  jitsi-jicofo-config:
+  jitsi-jvb-config:
+  vaultwarden-data:
+  uptime-kuma-data:
+  duplicati-config:
+  duplicati-backups:

--- a/deployments/small-church/.env.example
+++ b/deployments/small-church/.env.example
@@ -1,0 +1,41 @@
+# Small Church Stack Environment Variables
+
+# Domain Configuration
+# Point these subdomains to your server IP in DNS
+WORDPRESS_DOMAIN=www.yourchurch.com
+CHURCHCRM_DOMAIN=crm.yourchurch.com
+NEXTCLOUD_DOMAIN=files.yourchurch.com
+LISTMONK_DOMAIN=news.yourchurch.com
+UPTIME_DOMAIN=status.yourchurch.com
+
+# Let's Encrypt Configuration
+ACME_EMAIL=admin@yourchurch.com
+
+# Timezone
+TZ=America/New_York
+
+# Database Passwords - CHANGE THESE!
+# Generate: openssl rand -base64 24
+WORDPRESS_DB_PASSWORD=change_this_to_secure_password
+CHURCHCRM_DB_PASSWORD=change_this_to_secure_password_2
+NEXTCLOUD_DB_PASSWORD=change_this_to_secure_password_3
+MYSQL_ROOT_PASSWORD=secure_root_password_1
+MYSQL_ROOT_PASSWORD_2=secure_root_password_2
+MYSQL_ROOT_PASSWORD_3=secure_root_password_3
+
+# Nextcloud Admin
+NEXTCLOUD_ADMIN_USER=admin
+NEXTCLOUD_ADMIN_PASSWORD=change_this_admin_password
+
+# Listmonk Admin
+LISTMONK_ADMIN_USER=admin
+LISTMONK_ADMIN_PASSWORD=change_this_listmonk_password
+LISTMONK_DB_PASSWORD=secure_listmonk_db_password
+
+# Watchtower Notifications (optional)
+WATCHTOWER_EMAIL_FROM=admin@yourchurch.com
+WATCHTOWER_EMAIL_TO=admin@yourchurch.com
+WATCHTOWER_EMAIL_SERVER=smtp.gmail.com
+WATCHTOWER_EMAIL_PORT=587
+WATCHTOWER_EMAIL_USER=your-email@gmail.com
+WATCHTOWER_EMAIL_PASSWORD=your-app-password

--- a/deployments/small-church/README.md
+++ b/deployments/small-church/README.md
@@ -1,0 +1,335 @@
+# Small Church Stack
+
+> Balanced setup for established churches with 50-200 members.
+
+## What's Included
+
+| Function | Tool | Purpose |
+|----------|------|---------|
+| **Website** | WordPress | Sermons, events, announcements |
+| **ChMS** | ChurchCRM | Members, groups, check-in, giving tracking |
+| **Files** | Nextcloud | Document storage, collaboration, calendars |
+| **Email** | Listmonk | Newsletters, announcements, automated emails |
+| **Monitoring** | Uptime Kuma | Service health monitoring |
+| **Updates** | Watchtower | Automatic container updates |
+
+## System Requirements
+
+- **Server:** VPS with 2GB RAM (4GB recommended), 50GB storage
+- **OS:** Ubuntu 22.04 LTS or Debian 12
+- **Domain:** One domain with wildcard or multiple subdomains
+- **Skills:** Basic Linux, Docker familiarity, DNS management
+
+## Quick Start
+
+### 1. Prepare Your Server
+
+```bash
+# Update system
+sudo apt update && sudo apt upgrade -y
+
+# Install Docker
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+newgrp docker
+
+# Install Docker Compose
+sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+
+# Create directory
+mkdir -p ~/small-church && cd ~/small-church
+```
+
+### 2. Configure DNS
+
+Point these subdomains to your server IP:
+
+```
+www.yourchurch.com     → A Record → your-server-ip
+crm.yourchurch.com     → A Record → your-server-ip
+files.yourchurch.com   → A Record → your-server-ip
+news.yourchurch.com    → A Record → your-server-ip
+status.yourchurch.com  → A Record → your-server-ip
+```
+
+### 3. Download and Configure
+
+```bash
+# Download files
+curl -o docker-compose.yml https://raw.githubusercontent.com/church-tech-stack/main/stacks/small-church/docker-compose.yml
+curl -o .env.example https://raw.githubusercontent.com/church-tech-stack/main/stacks/small-church/.env.example
+cp .env.example .env
+
+# Edit configuration
+nano .env
+```
+
+### 4. Start the Stack
+
+```bash
+docker-compose up -d
+```
+
+Wait 2-3 minutes for all services to initialize.
+
+### 5. Complete Setup
+
+**WordPress:**
+- Visit `https://www.yourchurch.com`
+- Complete setup wizard
+- Install recommended plugins:
+  - Sermon Manager
+  - The Events Calendar
+  - WP Mail SMTP
+  - Wordfence Security
+
+**ChurchCRM:**
+- Visit `https://crm.yourchurch.com`
+- Create admin account
+- Configure email settings
+- Set up groups and Sunday School classes
+- Configure check-in for children's ministry
+
+**Nextcloud:**
+- Visit `https://files.yourchurch.com`
+- Admin account already created from environment variables
+- Install recommended apps:
+  - Calendar (share church calendars)
+  - Contacts (shared address book)
+  - Deck (project management)
+  - Forms (surveys, sign-ups)
+  - Polls (schedule voting)
+- Configure external storage if needed
+
+**Listmonk:**
+- Visit `https://news.yourchurch.com`
+- Login with credentials from .env
+- Configure SMTP settings (Settings → Settings → SMTP)
+- Create subscriber lists:
+  - All Church
+  - Staff
+  - Volunteers
+  - Parents
+- Import subscribers or add signup form to website
+- Create templates for newsletters
+
+**Uptime Kuma:**
+- Visit `https://status.yourchurch.com`
+- Create admin account
+- Add monitors for:
+  - https://www.yourchurch.com
+  - https://crm.yourchurch.com
+  - https://files.yourchurch.com
+  - https://news.yourchurch.com
+- Configure notifications (email, Discord, etc.)
+
+## Maintenance
+
+### Backup Strategy
+
+Create `backup.sh`:
+
+```bash
+#!/bin/bash
+set -e
+
+DATE=$(date +%Y%m%d_%H%M%S)
+BACKUP_DIR="$HOME/backups"
+mkdir -p $BACKUP_DIR
+
+echo "Starting backup at $DATE..."
+
+# WordPress
+docker run --rm -v small-church_wordpress-data:/data -v $BACKUP_DIR:/backup alpine \
+  tar czf /backup/wordpress_$DATE.tar.gz -C /data .
+docker exec small-church-wordpress-db mysqldump -u root -p${MYSQL_ROOT_PASSWORD} wordpress > \
+  $BACKUP_DIR/wordpress_db_$DATE.sql
+
+# ChurchCRM
+docker run --rm -v small-church_churchcrm-data:/data -v $BACKUP_DIR:/backup alpine \
+  tar czf /backup/churchcrm_$DATE.tar.gz -C /data .
+docker exec small-church-churchcrm-db mysqldump -u root -p${MYSQL_ROOT_PASSWORD_2} churchcrm > \
+  $BACKUP_DIR/churchcrm_db_$DATE.sql
+
+# Nextcloud
+docker run --rm -v small-church_nextcloud-data:/data -v $BACKUP_DIR:/backup alpine \
+  tar czf /backup/nextcloud_$DATE.tar.gz -C /data .
+docker exec small-church-nextcloud-db mysqldump -u root -p${MYSQL_ROOT_PASSWORD_3} nextcloud > \
+  $BACKUP_DIR/nextcloud_db_$DATE.sql
+
+# Listmonk
+docker run --rm -v small-church_listmonk-data:/data -v $BACKUP_DIR:/backup alpine \
+  tar czf /backup/listmonk_$DATE.tar.gz -C /data .
+docker exec small-church-listmonk-db pg_dump -U listmonk listmonk > \
+  $BACKUP_DIR/listmonk_db_$DATE.sql
+
+# Cleanup old backups (keep 14 days)
+find $BACKUP_DIR -name "*.tar.gz" -mtime +14 -delete
+find $BACKUP_DIR -name "*.sql" -mtime +14 -delete
+
+echo "Backup completed: $(date)"
+```
+
+Make executable and schedule:
+```bash
+chmod +x backup.sh
+# Add to crontab - runs daily at 2 AM
+(crontab -l 2>/dev/null; echo "0 2 * * * /home/youruser/small-church/backup.sh >> /var/log/church-backup.log 2>&1") | crontab -
+```
+
+### Restore from Backup
+
+```bash
+# Restore WordPress files
+docker run --rm -v small-church_wordpress-data:/data -v $BACKUP_DIR:/backup alpine \
+  sh -c "cd /data && tar xzf /backup/wordpress_YYYYMMDD_HHMMSS.tar.gz"
+
+# Restore WordPress database
+docker exec -i small-church-wordpress-db mysql -u root -p${MYSQL_ROOT_PASSWORD} wordpress < \
+  wordpress_db_YYYYMMDD_HHMMSS.sql
+```
+
+### Updates
+
+> **WARNING: Watchtower Risks**
+>
+> Watchtower automatically updates containers, which can break things without warning. Mitigations:
+> 1. **Monitor notifications** — Watchtower emails you when updates occur
+> 2. **Test backups monthly** — Ensure you can restore if an update breaks something
+> 3. **Consider pinning critical images** — Change `image: wordpress:latest` to `image: wordpress:6.4` for stability
+> 4. **No rollback built-in** — If an update breaks things, you must restore from backup or manually pull old image
+>
+> For production stability, consider disabling Watchtower and doing manual updates during maintenance windows.
+
+Watchtower handles automatic container updates. For application updates:
+
+**WordPress:** Use admin panel → Updates
+**ChurchCRM:** Built-in updater
+**Nextcloud:** Admin panel → Overview → Update
+**Listmonk:** Update container image version in docker-compose.yml
+
+### Monitoring
+
+Check Uptime Kuma dashboard regularly. Common issues:
+
+- **High CPU/Memory:** Check `docker stats`
+- **Slow Nextcloud:** Redis helps; consider enabling PHP OPcache
+- **Database errors:** Check individual service logs
+
+## Integration Guide
+
+### ChurchCRM ↔ WordPress
+
+1. Export members from ChurchCRM
+2. Use WP All Import plugin to create WordPress users
+3. Sync giving data manually or via custom script
+
+### Nextcloud ↔ ChurchCRM
+
+1. Export contacts from ChurchCRM
+2. Import to Nextcloud Contacts app
+3. Share church calendars publicly or with specific groups
+
+### Listmonk ↔ WordPress
+
+1. Add subscription form to WordPress footer/sidebar
+2. Use Listmonk subscription API
+3. Example integration plugin available
+
+### Listmonk ↔ ChurchCRM
+
+1. Export email list from ChurchCRM
+2. Import to Listmonk
+3. Set up regular sync via CSV export/import
+
+## Troubleshooting
+
+### Services won't start
+```bash
+# Check logs
+docker-compose logs [service-name]
+
+# Check disk space
+df -h
+
+# Check memory
+free -h
+```
+
+### SSL certificate issues
+```bash
+# Force renewal
+docker-compose down
+rm -f letsencrypt/acme.json
+docker-compose up -d
+```
+
+### Database connection errors
+```bash
+# Verify databases are healthy
+docker-compose ps
+
+# Check specific database logs
+docker-compose logs [db-name]
+```
+
+### Nextcloud performance issues
+```bash
+# Enable Redis in Nextcloud config
+docker exec -it small-church-nextcloud \
+  su -s /bin/sh www-data -c "php occ config:system:set memcache.local --value='\\OC\\Memcache\\Redis'"
+docker exec -it small-church-nextcloud \
+  su -s /bin/sh www-data -c "php occ config:system:set memcache.locking --value='\\OC\\Memcache\\Redis'"
+docker exec -it small-church-nextcloud \
+  su -s /bin/sh www-data -c "php occ config:system:set redis host --value=nextcloud-redis"
+```
+
+## Security Best Practices
+
+1. **Keep .env secure:** Never commit to git
+2. **Regular backups:** Daily automated, test restore monthly
+3. **Firewall:**
+   ```bash
+   sudo ufw allow 22/tcp
+   sudo ufw allow 80/tcp
+   sudo ufw allow 443/tcp
+   sudo ufw enable
+   ```
+4. **Fail2ban:** Install and configure for SSH protection
+5. **Updates:** Enable automatic security updates
+6. **Monitoring:** Check Uptime Kuma regularly
+7. **Nextcloud security:** Enable 2FA for all admin accounts
+
+## Scaling Considerations
+
+When approaching 200+ members:
+
+1. **Upgrade VPS:** 4GB RAM → 8GB RAM
+2. **Separate databases:** Consider dedicated database server
+3. **CDN:** Add Cloudflare for WordPress/Nextcloud
+4. **Object storage:** Move Nextcloud files to S3-compatible storage
+5. **Monitoring:** Add more detailed logging and alerting
+
+## Migration from Church Plant Stack
+
+1. Set up Small Church Stack on new server
+2. Export WordPress content (Tools → Export)
+3. Export ChurchCRM database
+4. Import to new stack
+5. Set up additional services
+6. Test thoroughly
+7. Update DNS
+8. Decommission old server
+
+## Support Resources
+
+- WordPress: https://wordpress.org/support/
+- ChurchCRM: https://github.com/ChurchCRM/CRM/wiki
+- Nextcloud: https://docs.nextcloud.com/
+- Listmonk: https://listmonk.app/docs/
+- Uptime Kuma: https://github.com/louislam/uptime-kuma
+
+---
+
+*Stack Version: 1.0 | Last Updated: 2026-02-03*

--- a/deployments/small-church/docker-compose.yml
+++ b/deployments/small-church/docker-compose.yml
@@ -1,0 +1,284 @@
+version: "3.8"
+
+# Small Church Stack - Balanced Setup
+# For established churches with 50-200 members
+# 
+# What's Included:
+# - WordPress (website + sermons)
+# - ChurchCRM (ChMS with check-in)
+# - Nextcloud (file storage, document collaboration)
+# - Listmonk (email newsletters)
+# - Uptime Kuma (monitoring)
+#
+# Requirements:
+# - 2GB RAM minimum, 4GB recommended
+# - Single domain with subdomains
+# - Docker and Docker Compose installed
+
+services:
+  # Traefik reverse proxy
+  traefik:
+    image: traefik:v2.10
+    container_name: small-church-traefik
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.letsencrypt.acme.tlschallenge=true"
+      - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL:-admin@example.com}"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
+      - "--ping=true"
+      - "--accesslog=true"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./letsencrypt:/letsencrypt
+      - ./traefik/access.log:/var/log/traefik/access.log
+    networks:
+      - small-church
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "traefik", "healthcheck", "--ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # WordPress - Website
+  wordpress:
+    image: wordpress:latest
+    container_name: small-church-wordpress
+    environment:
+      WORDPRESS_DB_HOST: wordpress-db
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: ${WORDPRESS_DB_PASSWORD:-changeme}
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - wordpress-data:/var/www/html
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.wordpress.rule=Host(`${WORDPRESS_DOMAIN:-www.example.com}`)"
+      - "traefik.http.routers.wordpress.entrypoints=websecure"
+      - "traefik.http.routers.wordpress.tls.certresolver=letsencrypt"
+      - "traefik.http.services.wordpress.loadbalancer.server.port=80"
+    networks:
+      - small-church
+    depends_on:
+      - wordpress-db
+    restart: unless-stopped
+
+  # WordPress Database
+  wordpress-db:
+    image: mysql:8.0
+    container_name: small-church-wordpress-db
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-changeme}
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: ${WORDPRESS_DB_PASSWORD:-changeme}
+    volumes:
+      - wordpress-db-data:/var/lib/mysql
+    networks:
+      - small-church
+    restart: unless-stopped
+    command: --default-authentication-plugin=mysql_native_password
+
+  # ChurchCRM - Church Management
+  churchcrm:
+    image: churchcrm/crm:latest
+    container_name: small-church-churchcrm
+    environment:
+      CRM_DB_HOST: churchcrm-db
+      CRM_DB_NAME: churchcrm
+      CRM_DB_USER: churchcrm
+      CRM_DB_PASS: ${CHURCHCRM_DB_PASSWORD:-changeme}
+    volumes:
+      - churchcrm-data:/var/www/churchcrm
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.churchcrm.rule=Host(`${CHURCHCRM_DOMAIN:-crm.example.com}`)"
+      - "traefik.http.routers.churchcrm.entrypoints=websecure"
+      - "traefik.http.routers.churchcrm.tls.certresolver=letsencrypt"
+      - "traefik.http.services.churchcrm.loadbalancer.server.port=80"
+    networks:
+      - small-church
+    depends_on:
+      - churchcrm-db
+    restart: unless-stopped
+
+  # ChurchCRM Database
+  churchcrm-db:
+    image: mariadb:10.6
+    container_name: small-church-churchcrm-db
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD_2:-changeme2}
+      MYSQL_DATABASE: churchcrm
+      MYSQL_USER: churchcrm
+      MYSQL_PASSWORD: ${CHURCHCRM_DB_PASSWORD:-changeme}
+    volumes:
+      - churchcrm-db-data:/var/lib/mysql
+    networks:
+      - small-church
+    restart: unless-stopped
+
+  # Nextcloud - File storage and collaboration
+  nextcloud:
+    image: nextcloud:latest
+    container_name: small-church-nextcloud
+    environment:
+      MYSQL_HOST: nextcloud-db
+      MYSQL_DATABASE: nextcloud
+      MYSQL_USER: nextcloud
+      MYSQL_PASSWORD: ${NEXTCLOUD_DB_PASSWORD:-changeme}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD_3:-changeme3}
+      NEXTCLOUD_ADMIN_USER: ${NEXTCLOUD_ADMIN_USER:-admin}
+      NEXTCLOUD_ADMIN_PASSWORD: ${NEXTCLOUD_ADMIN_PASSWORD:-changeme}
+      NEXTCLOUD_TRUSTED_DOMAINS: ${NEXTCLOUD_DOMAIN:-files.example.com}
+    volumes:
+      - nextcloud-data:/var/www/html
+      - nextcloud-apps:/var/www/html/custom_apps
+      - nextcloud-config:/var/www/html/config
+      - nextcloud-data-files:/var/www/html/data
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.nextcloud.rule=Host(`${NEXTCLOUD_DOMAIN:-files.example.com}`)"
+      - "traefik.http.routers.nextcloud.entrypoints=websecure"
+      - "traefik.http.routers.nextcloud.tls.certresolver=letsencrypt"
+      - "traefik.http.services.nextcloud.loadbalancer.server.port=80"
+      # WebDAV fix for Traefik
+      - "traefik.http.middlewares.nextcloud-dav.replacepathregex.regex=^/.well-known/(card|cal)dav"
+      - "traefik.http.middlewares.nextcloud-dav.replacepathregex.replacement=/remote.php/dav/"
+      - "traefik.http.routers.nextcloud.middlewares=nextcloud-dav"
+    networks:
+      - small-church
+    depends_on:
+      - nextcloud-db
+    restart: unless-stopped
+
+  # Nextcloud Database
+  nextcloud-db:
+    image: mariadb:10.6
+    container_name: small-church-nextcloud-db
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD_3:-changeme3}
+      MYSQL_DATABASE: nextcloud
+      MYSQL_USER: nextcloud
+      MYSQL_PASSWORD: ${NEXTCLOUD_DB_PASSWORD:-changeme}
+    volumes:
+      - nextcloud-db-data:/var/lib/mysql
+    networks:
+      - small-church
+    restart: unless-stopped
+
+  # Redis for Nextcloud performance
+  nextcloud-redis:
+    image: redis:alpine
+    container_name: small-church-nextcloud-redis
+    volumes:
+      - nextcloud-redis-data:/data
+    networks:
+      - small-church
+    restart: unless-stopped
+
+  # Listmonk - Email newsletters
+  listmonk:
+    image: listmonk/listmonk:latest
+    container_name: small-church-listmonk
+    environment:
+      LISTMONK_app__address: "0.0.0.0:9000"
+      LISTMONK_app__admin_username: ${LISTMONK_ADMIN_USER:-admin}
+      LISTMONK_app__admin_password: ${LISTMONK_ADMIN_PASSWORD:-changeme}
+      LISTMONK_db__host: listmonk-db
+      LISTMONK_db__port: "5432"
+      LISTMONK_db__user: listmonk
+      LISTMONK_db__password: ${LISTMONK_DB_PASSWORD:-changeme}
+      LISTMONK_db__database: listmonk
+      LISTMONK_db__ssl_mode: disable
+      TZ: ${TZ:-America/New_York}
+    volumes:
+      - listmonk-data:/listmonk/uploads
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.listmonk.rule=Host(`${LISTMONK_DOMAIN:-news.example.com}`)"
+      - "traefik.http.routers.listmonk.entrypoints=websecure"
+      - "traefik.http.routers.listmonk.tls.certresolver=letsencrypt"
+      - "traefik.http.services.listmonk.loadbalancer.server.port=9000"
+    networks:
+      - small-church
+    depends_on:
+      - listmonk-db
+    restart: unless-stopped
+    command: [sh, -c, "./listmonk --install --idempotent && ./listmonk"]
+
+  # Listmonk Database
+  listmonk-db:
+    image: postgres:15-alpine
+    container_name: small-church-listmonk-db
+    environment:
+      POSTGRES_PASSWORD: ${LISTMONK_DB_PASSWORD:-changeme}
+      POSTGRES_USER: listmonk
+      POSTGRES_DB: listmonk
+    volumes:
+      - listmonk-db-data:/var/lib/postgresql/data
+    networks:
+      - small-church
+    restart: unless-stopped
+
+  # Uptime Kuma - Monitoring
+  uptime-kuma:
+    image: louislam/uptime-kuma:latest
+    container_name: small-church-uptime-kuma
+    volumes:
+      - uptime-kuma-data:/app/data
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.uptime-kuma.rule=Host(`${UPTIME_DOMAIN:-status.example.com}`)"
+      - "traefik.http.routers.uptime-kuma.entrypoints=websecure"
+      - "traefik.http.routers.uptime-kuma.tls.certresolver=letsencrypt"
+      - "traefik.http.services.uptime-kuma.loadbalancer.server.port=3001"
+      - "traefik.http.middlewares.uptime-kuma-headers.headers.customrequestheaders.X-Forwarded-Proto=https"
+      - "traefik.http.routers.uptime-kuma.middlewares=uptime-kuma-headers"
+    networks:
+      - small-church
+    restart: unless-stopped
+
+  # Watchtower - Automatic container updates
+  watchtower:
+    image: containrrr/watchtower:latest
+    container_name: small-church-watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - WATCHTOWER_CLEANUP=true
+      - WATCHTOWER_POLL_INTERVAL=86400
+      - WATCHTOWER_NOTIFICATIONS=email
+      - WATCHTOWER_NOTIFICATION_EMAIL_FROM=${WATCHTOWER_EMAIL_FROM:-admin@example.com}
+      - WATCHTOWER_NOTIFICATION_EMAIL_TO=${WATCHTOWER_EMAIL_TO:-admin@example.com}
+      - WATCHTOWER_NOTIFICATION_EMAIL_SERVER=${WATCHTOWER_EMAIL_SERVER:-smtp.gmail.com}
+      - WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT=${WATCHTOWER_EMAIL_PORT:-587}
+      - WATCHTOWER_NOTIFICATION_EMAIL_SERVER_USER=${WATCHTOWER_EMAIL_USER}
+      - WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD=${WATCHTOWER_EMAIL_PASSWORD}
+    restart: unless-stopped
+
+networks:
+  small-church:
+    driver: bridge
+
+volumes:
+  wordpress-data:
+  wordpress-db-data:
+  churchcrm-data:
+  churchcrm-db-data:
+  nextcloud-data:
+  nextcloud-apps:
+  nextcloud-config:
+  nextcloud-data-files:
+  nextcloud-db-data:
+  nextcloud-redis-data:
+  listmonk-data:
+  listmonk-db-data:
+  uptime-kuma-data:

--- a/deployments/starter/.env.example
+++ b/deployments/starter/.env.example
@@ -1,0 +1,37 @@
+# Church Starter Stack Configuration
+# Copy this file to .env and fill in your values
+
+# ===================
+# YOUR DOMAIN NAMES
+# ===================
+# These must point to your server's IP address in DNS
+WORDPRESS_DOMAIN=www.yourchurch.com
+CHURCHCRM_DOMAIN=members.yourchurch.com
+LISTMONK_DOMAIN=news.yourchurch.com
+VAULTWARDEN_DOMAIN=vault.yourchurch.com
+
+# ===================
+# YOUR EMAIL
+# ===================
+# Used for SSL certificate notifications
+ACME_EMAIL=pastor@yourchurch.com
+
+# ===================
+# PASSWORDS
+# ===================
+# Generate strong passwords - use: openssl rand -base64 24
+
+# WordPress database password
+WORDPRESS_DB_PASSWORD=CHANGE_ME_1
+
+# ChurchCRM database password
+CHURCHCRM_DB_PASSWORD=CHANGE_ME_2
+
+# Listmonk admin login
+LISTMONK_USER=admin
+LISTMONK_PASSWORD=CHANGE_ME_3
+LISTMONK_DB_PASSWORD=CHANGE_ME_4
+
+# Vaultwarden admin token (for creating accounts)
+# Generate with: openssl rand -base64 48
+VAULTWARDEN_ADMIN_TOKEN=CHANGE_ME_5

--- a/deployments/starter/README.md
+++ b/deployments/starter/README.md
@@ -1,0 +1,277 @@
+# Starter Stack
+
+> Get your church online with member management, a website, newsletters, and secure password sharing — in about an hour.
+
+## What You Get
+
+| Tool | What It Does | Replaces |
+|------|--------------|----------|
+| **WordPress** | Church website with sermons, events, contact forms | Wix, Squarespace |
+| **ChurchCRM** | Track members, groups, attendance, giving | Planning Center, Breeze |
+| **Listmonk** | Send email newsletters to your congregation | Mailchimp |
+| **Vaultwarden** | Share passwords securely with staff | LastPass, shared spreadsheets |
+
+**Total cost:** $5-10/month for a small VPS (DigitalOcean, Linode, Vultr)
+
+## What You Need
+
+- A domain name (e.g., yourchurch.com)
+- A VPS with 2GB RAM ($10-12/month) running Ubuntu 22.04
+- About 1 hour for initial setup
+- Basic comfort with command line (copy/paste is fine)
+
+## Setup Guide
+
+### Step 1: Get a Server
+
+Sign up for a VPS at [DigitalOcean](https://digitalocean.com), [Linode](https://linode.com), or [Vultr](https://vultr.com).
+
+- Choose **Ubuntu 22.04 LTS**
+- Choose **2GB RAM** ($10-12/month)
+- Choose a location near your congregation
+
+Save the IP address they give you.
+
+### Step 2: Point Your Domain
+
+Log into your domain registrar and create these DNS records pointing to your server IP:
+
+```
+www.yourchurch.com      → A Record → YOUR_SERVER_IP
+members.yourchurch.com  → A Record → YOUR_SERVER_IP
+news.yourchurch.com     → A Record → YOUR_SERVER_IP
+vault.yourchurch.com    → A Record → YOUR_SERVER_IP
+```
+
+Wait 5-10 minutes for DNS to propagate.
+
+### Step 3: Connect to Your Server
+
+On Mac/Linux, open Terminal. On Windows, use PowerShell.
+
+```bash
+ssh root@YOUR_SERVER_IP
+```
+
+Type "yes" when asked about fingerprints, then enter your password.
+
+### Step 4: Install Docker
+
+Copy and paste these commands one at a time:
+
+```bash
+# Update the system
+apt update && apt upgrade -y
+
+# Install Docker
+curl -fsSL https://get.docker.com | sh
+
+# Install Docker Compose plugin
+apt install docker-compose-plugin -y
+```
+
+### Step 5: Download the Stack
+
+```bash
+# Create a folder for your church stack
+mkdir -p /opt/church && cd /opt/church
+
+# Download the configuration files
+curl -O https://raw.githubusercontent.com/church-tech-stack/main/stacks/starter/docker-compose.yml
+curl -O https://raw.githubusercontent.com/church-tech-stack/main/stacks/starter/.env.example
+
+# Create your configuration file
+cp .env.example .env
+```
+
+### Step 6: Configure Your Settings
+
+```bash
+nano .env
+```
+
+Update these values:
+- Replace `yourchurch.com` with your actual domain
+- Replace `CHANGE_ME_X` passwords with strong passwords
+
+To generate strong passwords, open a new terminal and run:
+```bash
+openssl rand -base64 24
+```
+
+Save the file: Press `Ctrl+X`, then `Y`, then `Enter`.
+
+### Step 7: Start Everything
+
+```bash
+docker compose up -d
+```
+
+Wait 2-3 minutes for everything to start. Check status with:
+```bash
+docker compose ps
+```
+
+All services should show "running".
+
+### Step 8: Complete Setup for Each Service
+
+**WordPress** (https://www.yourchurch.com)
+1. Follow the setup wizard
+2. Pick a theme (search "flavor starter theme" for good ones)
+3. Recommended plugins: Jewtify (sermons) and The Events Calendar
+
+**ChurchCRM** (https://members.yourchurch.com)
+1. Create your admin account
+2. Add your church info in Settings
+3. Start adding members manually or import from CSV
+
+**Listmonk** (https://news.yourchurch.com)
+1. Log in with credentials from your .env file
+2. Go to Settings → Settings → SMTP to configure email sending
+3. Create your first mailing list (e.g., "Weekly Newsletter")
+
+**Vaultwarden** (https://vault.yourchurch.com)
+1. Go to https://vault.yourchurch.com/admin
+2. Enter your admin token from .env
+3. Invite staff members via email
+4. Have everyone install the Bitwarden app (it works with Vaultwarden)
+
+## Day-to-Day Use
+
+### Sending Newsletters
+
+1. Log into Listmonk
+2. Click Campaigns → New
+3. Write your newsletter
+4. Select your list and send
+
+### Adding New Members
+
+1. Log into ChurchCRM
+2. Click People → Add New Family
+3. Fill in details
+
+### Updating Your Website
+
+1. Log into WordPress
+2. Edit pages, add sermons, update events
+
+### Sharing Passwords with Staff
+
+1. Open Bitwarden app (or browser extension)
+2. Create an Organization for your church
+3. Add shared items (WiFi password, social media logins, etc.)
+4. Invite staff to the organization
+
+## Backups
+
+**Critical:** Set up backups or you will lose everything if your server fails.
+
+Create a backup script:
+
+```bash
+nano /opt/church/backup.sh
+```
+
+Paste this:
+
+```bash
+#!/bin/bash
+DATE=$(date +%Y%m%d)
+BACKUP_DIR="/opt/church/backups"
+mkdir -p $BACKUP_DIR
+
+# Backup all data
+docker run --rm \
+  -v starter_wordpress-data:/source/wordpress:ro \
+  -v starter_churchcrm-data:/source/churchcrm:ro \
+  -v starter_vaultwarden-data:/source/vaultwarden:ro \
+  -v starter_listmonk-data:/source/listmonk:ro \
+  -v $BACKUP_DIR:/backup \
+  alpine tar czf /backup/church-backup-$DATE.tar.gz -C /source .
+
+# Backup databases
+docker exec starter-wordpress-db mysqldump -u wordpress -p${WORDPRESS_DB_PASSWORD} wordpress > $BACKUP_DIR/wordpress-$DATE.sql
+docker exec starter-churchcrm-db mysqldump -u churchcrm -p${CHURCHCRM_DB_PASSWORD} churchcrm > $BACKUP_DIR/churchcrm-$DATE.sql
+docker exec starter-listmonk-db pg_dump -U listmonk listmonk > $BACKUP_DIR/listmonk-$DATE.sql
+
+# Keep only last 7 days
+find $BACKUP_DIR -name "*.tar.gz" -mtime +7 -delete
+find $BACKUP_DIR -name "*.sql" -mtime +7 -delete
+
+echo "Backup complete: $DATE"
+```
+
+Make it run automatically:
+
+```bash
+chmod +x /opt/church/backup.sh
+
+# Run daily at 2 AM
+(crontab -l 2>/dev/null; echo "0 2 * * * /opt/church/backup.sh") | crontab -
+```
+
+**Important:** Copy backups offsite! Use `scp` to copy to another computer or set up automatic sync to Backblaze B2 ($5/month for plenty of storage).
+
+## Updates
+
+Update your services monthly:
+
+```bash
+cd /opt/church
+docker compose pull
+docker compose up -d
+```
+
+Update WordPress plugins through the WordPress admin panel.
+
+## Troubleshooting
+
+### "Site can't be reached"
+
+```bash
+# Check if services are running
+docker compose ps
+
+# Check logs for errors
+docker compose logs wordpress
+docker compose logs traefik
+```
+
+### "SSL certificate error"
+
+Wait 5 minutes — certificates take time to generate. If still failing:
+
+```bash
+# Check Traefik logs
+docker compose logs traefik
+
+# Verify DNS is pointing to your server
+dig +short www.yourchurch.com
+```
+
+### "Forgot my password"
+
+For WordPress, Listmonk, or ChurchCRM — use their built-in password reset via email.
+
+For Vaultwarden admin token — it's in your .env file.
+
+## Getting Help
+
+- WordPress: https://wordpress.org/support/
+- ChurchCRM: https://github.com/ChurchCRM/CRM/wiki
+- Listmonk: https://listmonk.app/docs/
+- Vaultwarden: https://github.com/dani-garcia/vaultwarden/wiki
+
+## Next Steps
+
+When you outgrow this stack:
+
+- **Need file sharing?** → Graduate to Small Church Stack (adds Nextcloud)
+- **Need video calls?** → Graduate to Privacy-First Stack (adds Jitsi)
+- **Need monitoring?** → Add Uptime Kuma to get alerts when things go down
+
+---
+
+*Keep it simple. Serve your people.*

--- a/deployments/starter/docker-compose.yml
+++ b/deployments/starter/docker-compose.yml
@@ -1,0 +1,170 @@
+services:
+  # Traefik - handles HTTPS automatically
+  traefik:
+    image: traefik:v2.10
+    container_name: starter-traefik
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.letsencrypt.acme.tlschallenge=true"
+      - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL}"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - letsencrypt:/letsencrypt
+    networks:
+      - church
+    restart: unless-stopped
+
+  # WordPress - Your church website
+  wordpress:
+    image: wordpress:6.4
+    container_name: starter-wordpress
+    environment:
+      WORDPRESS_DB_HOST: wordpress-db
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: ${WORDPRESS_DB_PASSWORD}
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - wordpress-data:/var/www/html
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.wordpress.rule=Host(`${WORDPRESS_DOMAIN}`)"
+      - "traefik.http.routers.wordpress.entrypoints=websecure"
+      - "traefik.http.routers.wordpress.tls.certresolver=letsencrypt"
+    networks:
+      - church
+    depends_on:
+      - wordpress-db
+    restart: unless-stopped
+
+  wordpress-db:
+    image: mysql:8.0
+    container_name: starter-wordpress-db
+    environment:
+      MYSQL_ROOT_PASSWORD: ${WORDPRESS_DB_PASSWORD}
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: ${WORDPRESS_DB_PASSWORD}
+    volumes:
+      - wordpress-db-data:/var/lib/mysql
+    networks:
+      - church
+    restart: unless-stopped
+
+  # ChurchCRM - Member management
+  churchcrm:
+    image: churchcrm/crm:latest
+    container_name: starter-churchcrm
+    environment:
+      CRM_DB_HOST: churchcrm-db
+      CRM_DB_NAME: churchcrm
+      CRM_DB_USER: churchcrm
+      CRM_DB_PASS: ${CHURCHCRM_DB_PASSWORD}
+    volumes:
+      - churchcrm-data:/var/www/churchcrm
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.churchcrm.rule=Host(`${CHURCHCRM_DOMAIN}`)"
+      - "traefik.http.routers.churchcrm.entrypoints=websecure"
+      - "traefik.http.routers.churchcrm.tls.certresolver=letsencrypt"
+    networks:
+      - church
+    depends_on:
+      - churchcrm-db
+    restart: unless-stopped
+
+  churchcrm-db:
+    image: mariadb:10.6
+    container_name: starter-churchcrm-db
+    environment:
+      MYSQL_ROOT_PASSWORD: ${CHURCHCRM_DB_PASSWORD}
+      MYSQL_DATABASE: churchcrm
+      MYSQL_USER: churchcrm
+      MYSQL_PASSWORD: ${CHURCHCRM_DB_PASSWORD}
+    volumes:
+      - churchcrm-db-data:/var/lib/mysql
+    networks:
+      - church
+    restart: unless-stopped
+
+  # Listmonk - Email newsletters
+  listmonk:
+    image: listmonk/listmonk:latest
+    container_name: starter-listmonk
+    environment:
+      LISTMONK_app__address: "0.0.0.0:9000"
+      LISTMONK_app__admin_username: ${LISTMONK_USER}
+      LISTMONK_app__admin_password: ${LISTMONK_PASSWORD}
+      LISTMONK_db__host: listmonk-db
+      LISTMONK_db__port: "5432"
+      LISTMONK_db__user: listmonk
+      LISTMONK_db__password: ${LISTMONK_DB_PASSWORD}
+      LISTMONK_db__database: listmonk
+      LISTMONK_db__ssl_mode: disable
+    volumes:
+      - listmonk-data:/listmonk/uploads
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.listmonk.rule=Host(`${LISTMONK_DOMAIN}`)"
+      - "traefik.http.routers.listmonk.entrypoints=websecure"
+      - "traefik.http.routers.listmonk.tls.certresolver=letsencrypt"
+      - "traefik.http.services.listmonk.loadbalancer.server.port=9000"
+    networks:
+      - church
+    depends_on:
+      - listmonk-db
+    restart: unless-stopped
+    command: [sh, -c, "./listmonk --install --idempotent && ./listmonk"]
+
+  listmonk-db:
+    image: postgres:15-alpine
+    container_name: starter-listmonk-db
+    environment:
+      POSTGRES_PASSWORD: ${LISTMONK_DB_PASSWORD}
+      POSTGRES_USER: listmonk
+      POSTGRES_DB: listmonk
+    volumes:
+      - listmonk-db-data:/var/lib/postgresql/data
+    networks:
+      - church
+    restart: unless-stopped
+
+  # Vaultwarden - Password manager for staff
+  vaultwarden:
+    image: vaultwarden/server:latest
+    container_name: starter-vaultwarden
+    environment:
+      SIGNUPS_ALLOWED: "false"
+      ADMIN_TOKEN: ${VAULTWARDEN_ADMIN_TOKEN}
+      DOMAIN: https://${VAULTWARDEN_DOMAIN}
+    volumes:
+      - vaultwarden-data:/data
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.vaultwarden.rule=Host(`${VAULTWARDEN_DOMAIN}`)"
+      - "traefik.http.routers.vaultwarden.entrypoints=websecure"
+      - "traefik.http.routers.vaultwarden.tls.certresolver=letsencrypt"
+    networks:
+      - church
+    restart: unless-stopped
+
+networks:
+  church:
+    driver: bridge
+
+volumes:
+  letsencrypt:
+  wordpress-data:
+  wordpress-db-data:
+  churchcrm-data:
+  churchcrm-db-data:
+  listmonk-data:
+  listmonk-db-data:
+  vaultwarden-data:


### PR DESCRIPTION
## Summary

- Add 4 Docker Compose deployment tiers (Starter, Church Plant, Small Church, Privacy-First)
- Add detailed category documentation for Volunteer Scheduling and Children's Check-In
- All deployments use Traefik for automatic SSL via Let's Encrypt

## Deployments Added

| Stack | Best For | What's Included |
|-------|----------|-----------------|
| **Starter** | Most churches | WordPress, ChurchCRM, Listmonk, Vaultwarden |
| Church Plant | Minimal setup | WordPress, ChurchCRM |
| Small Church | Need file sharing | + Nextcloud, Monitoring |
| Privacy-First | Full self-hosted | + Jitsi, OnlyOffice, Backups |

Each deployment includes:
- `docker-compose.yml` (validated)
- `.env.example` with all required variables
- Detailed README with setup instructions, backup procedures, and troubleshooting

## Category Documentation Added

- **Volunteer Scheduling**: Reviews OpenVolunteerPlatform, Volunteer Planner, Rallly, and ChurchApps with comparison matrix and recommendations by church size
- **Children's Check-In**: Security-focused guide covering ChurchApps, ChurchCRM extensions, Jethro, and DIY architecture with database schema

## Test plan

- [x] All docker-compose files validate with `docker compose config`
- [x] Environment templates include all required variables
- [ ] Documentation renders correctly in GitHub

🤖 Generated with [Claude Code](https://claude.ai/code)